### PR TITLE
Avoid string copies (and garbage) in the asds

### DIFF
--- a/ocaml/src/alba.ml
+++ b/ocaml/src/alba.ml
@@ -71,9 +71,9 @@ let osd_multi_get osd_id cfg_file keys unescape =
                       then Scanf.unescaped key
                       else key)))
                 keys >>= fun values_s ->
-              let values = List.map(fun v -> Option.map
-                                               Bigstring_slice.to_string v)
-                                   values_s in
+              let values = List.map
+                             (fun v -> Option.map Lwt_bytes.to_string v)
+                             values_s in
               Lwt_io.printlf "%s" ([%show : string option list] values)))
   in
   lwt_cmd_line false t

--- a/ocaml/src/alba.ml
+++ b/ocaml/src/alba.ml
@@ -72,7 +72,7 @@ let osd_multi_get osd_id cfg_file keys unescape =
                       else key)))
                 keys >>= fun values_s ->
               let values = List.map(fun v -> Option.map
-                                               Slice.get_string_unsafe v)
+                                               Bigstring_slice.to_string v)
                                    values_s in
               Lwt_io.printlf "%s" ([%show : string option list] values)))
   in
@@ -254,7 +254,7 @@ let alba_upload_object
                              else NoPrevious)
            ~checksum_o:None
          >>= fun _ ->
-         Lwt_io.printlf "object %s was succesfully uploaded"
+         Lwt_io.printlf "object %s was successfully uploaded"
                         input_file
       )
   in

--- a/ocaml/src/alba_client_download.ml
+++ b/ocaml/src/alba_client_download.ml
@@ -48,7 +48,7 @@ let download_packed_fragment
       ~namespace_id
       ~object_id ~object_name
       ~chunk_id ~fragment_id
-      fragment_cache
+      (fragment_cache : Fragment_cache.cache)
   =
 
   let osd_id_o, version_id = location in
@@ -110,15 +110,14 @@ let download_packed_fragment
             Lwt.ignore_result
               (fragment_cache # add
                               namespace_id key_string
-                              (* TODO *)
-                              (Bigstring_slice.to_string data)
+                              data
               );
             let hit_or_mis = false in
             E.return (osd_id, hit_or_mis, data)
        end
     | Some data ->
        let hit_or_mis = true in
-       E.return (osd_id, hit_or_mis, Bigstring_slice.of_string data)
+       E.return (osd_id, hit_or_mis, data)
   in
   retrieve key
 
@@ -135,7 +134,7 @@ let download_fragment
       ~fragment_checksum
       decompress
       ~encryption
-      fragment_cache
+      (fragment_cache : Fragment_cache.cache)
   =
 
   let t0_fragment = Unix.gettimeofday () in
@@ -161,7 +160,7 @@ let download_fragment
    then E.return ()
    else
      begin
-       Lwt_bytes.unsafe_destroy fragment_data.Bigstring_slice.bs;
+       Lwt_bytes.unsafe_destroy fragment_data;
        E.fail `ChecksumMismatch
      end) >>== fun () ->
 

--- a/ocaml/src/alba_client_download.ml
+++ b/ocaml/src/alba_client_download.ml
@@ -110,11 +110,9 @@ let download_packed_fragment
          | Some data ->
             osd_access # get_osd_info ~osd_id >>= fun (_, state) ->
             Osd_state.add_read state;
-            Lwt.ignore_result
-              (fragment_cache # add
-                              namespace_id key_string
-                              data
-              );
+            fragment_cache # add
+                           namespace_id key_string
+                           data >>= fun () ->
             let hit_or_mis = false in
             E.return (osd_id, hit_or_mis, data)
        end

--- a/ocaml/src/alba_client_download.ml
+++ b/ocaml/src/alba_client_download.ml
@@ -42,6 +42,9 @@ let get_object_manifest'
 module E = Prelude.Error.Lwt
 let (>>==) = E.bind
 
+(* consumers of this method are responsible for freeing
+ * the returned fragment bigstring
+ *)
 let download_packed_fragment
       (osd_access : osd_access)
       ~location

--- a/ocaml/src/alba_client_download.ml
+++ b/ocaml/src/alba_client_download.ml
@@ -104,20 +104,21 @@ let download_packed_fragment
             in
             Lwt_log.warning msg >>= fun () ->
             E.fail `FragmentMissing
-         | Some (data:Slice.t) ->
+         | Some data ->
             osd_access # get_osd_info ~osd_id >>= fun (_, state) ->
             Osd_state.add_read state;
             Lwt.ignore_result
               (fragment_cache # add
                               namespace_id key_string
-                              (Slice.get_string_unsafe data)
+                              (* TODO *)
+                              (Bigstring_slice.to_string data)
               );
             let hit_or_mis = false in
             E.return (osd_id, hit_or_mis, data)
        end
     | Some data ->
        let hit_or_mis = true in
-       E.return (osd_id, hit_or_mis, Slice.wrap_string data)
+       E.return (osd_id, hit_or_mis, Bigstring_slice.of_string data)
   in
   retrieve key
 
@@ -150,11 +151,9 @@ let download_fragment
        fragment_cache)
   >>== fun (t_retrieve, (osd_id, hit_or_miss, fragment_data)) ->
 
-  let fragment_data' = Slice.to_bigstring fragment_data in
-
   E.with_timing
     (fun () ->
-     Fragment_helper.verify fragment_data' fragment_checksum
+     Fragment_helper.verify fragment_data fragment_checksum
      >>= E.return)
   >>== fun (t_verify, checksum_valid) ->
 
@@ -162,7 +161,7 @@ let download_fragment
    then E.return ()
    else
      begin
-       Lwt_bytes.unsafe_destroy fragment_data';
+       Lwt_bytes.unsafe_destroy fragment_data.Bigstring_slice.bs;
        E.fail `ChecksumMismatch
      end) >>== fun () ->
 
@@ -172,13 +171,13 @@ let download_fragment
        encryption
        ~object_id ~chunk_id ~fragment_id
        ~ignore_fragment_id:replication
-       fragment_data'
+       fragment_data
      >>= E.return)
   >>== fun (t_decrypt, maybe_decrypted) ->
 
   E.with_timing
     (fun () ->
-     decompress ~release_input:true maybe_decrypted
+     decompress maybe_decrypted
      >>= E.return)
   >>== fun (t_decompress, (maybe_decompressed : Lwt_bytes.t)) ->
 

--- a/ocaml/src/alba_client_message_delivery.ml
+++ b/ocaml/src/alba_client_message_delivery.ml
@@ -108,7 +108,7 @@ type dest msg.
                         Osd'.Assert.value_option
                           (Slice.wrap_string DK.next_msg_id)
                           (Option.map
-                             (fun x -> Asd_protocol.Blob.Bigslice x)
+                             (fun x -> Asd_protocol.Blob.Lwt_bytes x)
                              next_id_so)
                         :: asserts
                       in

--- a/ocaml/src/alba_client_message_delivery.ml
+++ b/ocaml/src/alba_client_message_delivery.ml
@@ -63,7 +63,9 @@ type dest msg.
               >>= fun next_id_so ->
               let next_id = match next_id_so with
                 | None -> 0l
-                | Some next_id_s -> deserialize Llio.int32_from (Slice.get_string_unsafe next_id_s)
+                | Some next_id_s ->
+                   let module L = Llio2.ReadBuffer in
+                   L.deserialize' L.int32_from next_id_s
               in
               Lwt.return (next_id_so, next_id)
             in
@@ -105,7 +107,10 @@ type dest msg.
                       let asserts' =
                         Osd'.Assert.value_option
                           (Slice.wrap_string DK.next_msg_id)
-                          next_id_so :: asserts
+                          (Option.map
+                             (fun x -> Asd_protocol.Blob.Bigslice x)
+                             next_id_so)
+                        :: asserts
                       in
                       client # apply_sequence
                              (osd_access # get_default_osd_priority)

--- a/ocaml/src/alba_client_osd.ml
+++ b/ocaml/src/alba_client_osd.ml
@@ -46,7 +46,7 @@ let claim_osd mgr_access osd_access ~long_id =
        | Some _ ->
           osd # get_exn Osd.High (wrap_string (IRK.instance_log_key 0l))
           >>= fun alba_id' ->
-          let u_alba_id' = get_string_unsafe alba_id' in
+          let u_alba_id' = Bigstring_slice.to_string alba_id' in
           if u_alba_id' = alba_id
           then Lwt.return `Continue
           else Lwt.return (`ClaimedBy u_alba_id')
@@ -66,7 +66,10 @@ let claim_osd mgr_access osd_access ~long_id =
                 Assert.none_string instance_index_key; ]
               [ Update.set
                   next_alba_instance'
-                  (wrap_string (serialize Llio.int32_to (Int32.succ id_on_osd)))
+                  (serialize
+                     Llio.int32_to
+                     (Int32.succ id_on_osd)
+                   |> fun x -> Asd_protocol.Blob.Bytes x)
                   no_checksum true;
                 Update.set_string
                   instance_log_key
@@ -85,7 +88,7 @@ let claim_osd mgr_access osd_access ~long_id =
                      Osd.High
                      (wrap_string (IRK.instance_log_key 0l))
                  >>= fun alba_id'slice ->
-                 let alba_id' = get_string_unsafe alba_id'slice in
+                 let alba_id' =  Bigstring_slice.to_string alba_id'slice in
                  let r =
                    if alba_id' = alba_id
                    then `Continue

--- a/ocaml/src/alba_client_osd.ml
+++ b/ocaml/src/alba_client_osd.ml
@@ -46,7 +46,7 @@ let claim_osd mgr_access osd_access ~long_id =
        | Some _ ->
           osd # get_exn Osd.High (wrap_string (IRK.instance_log_key 0l))
           >>= fun alba_id' ->
-          let u_alba_id' = Bigstring_slice.to_string alba_id' in
+          let u_alba_id' = Lwt_bytes.to_string alba_id' in
           Lwt_log.debug_f
             "osd %s is owned by %s, want to claim for %s"
             long_id u_alba_id' alba_id >>= fun () ->
@@ -95,7 +95,7 @@ let claim_osd mgr_access osd_access ~long_id =
                      Osd.High
                      (wrap_string (IRK.instance_log_key 0l))
                  >>= fun alba_id'slice ->
-                 let alba_id' =  Bigstring_slice.to_string alba_id'slice in
+                 let alba_id' =  Lwt_bytes.to_string alba_id'slice in
                  Lwt_log.debug_f
                    "got an error while claiming osd %s. it is now owned by %s (wanted to claim for %s)"
                    long_id alba_id' alba_id >>= fun () ->

--- a/ocaml/src/alba_test.ml
+++ b/ocaml/src/alba_test.ml
@@ -296,7 +296,7 @@ let test_delete_namespace () =
                 c # get_option
                   Osd.High
                   (wrap_string (AlbaInstance.namespace_status ~namespace_id)) >>= fun ps ->
-                let p = Option.map get_string_unsafe ps in
+                let p = Option.map Bigstring_slice.to_string ps in
                 Lwt_io.printlf "got p = %s" ([%show : string option] p) >>= fun () ->
                 assert (presence = (p <> None));
                 let fragment_key = wrap_string
@@ -308,7 +308,7 @@ let test_delete_namespace () =
                                      )
                 in
                 c # get_option Osd.High fragment_key >>= fun fs ->
-                let f = Option.map get_string_unsafe fs in
+                let f = Option.map Bigstring_slice.to_string fs in
                 Lwt_io.printlf "got f = %s" ([%show : string option] f) >>= fun () ->
                 assert (fragment = (f <> None));
                 Lwt.return ()) in
@@ -414,13 +414,13 @@ let test_garbage_collect () =
          Alba_client_upload.upload_packed_fragment_data
            (client # osd_access)
            ~namespace_id
-           ~packed_fragment:(Slice.create 1)
+           ~packed_fragment:(Bigstring_slice.create 1)
            ~osd_id ~version_id
            ~object_id
            ~chunk_id ~fragment_id
            ~gc_epoch:0L
            ~checksum:Checksum.Checksum.NoChecksum
-           ~recovery_info_slice:(Slice.wrap_string "")
+           ~recovery_info_blob:(Osd.Blob.Bytes "")
          >>= fun _ ->
 
          let assert_fragment assert_ =
@@ -743,7 +743,7 @@ let test_discover_claimed () =
                 Assert.none_string instance_index_key; ]
               [ Update.set
                   next_alba_instance'
-                  (wrap_string (serialize Llio.int32_to (Int32.succ id_on_osd)))
+                  (Osd.Blob.Bytes (serialize Llio.int32_to (Int32.succ id_on_osd)))
                   no_checksum true;
                 Update.set_string
                   instance_log_key

--- a/ocaml/src/alba_test.ml
+++ b/ocaml/src/alba_test.ml
@@ -296,7 +296,7 @@ let test_delete_namespace () =
                 c # get_option
                   Osd.High
                   (wrap_string (AlbaInstance.namespace_status ~namespace_id)) >>= fun ps ->
-                let p = Option.map Bigstring_slice.to_string ps in
+                let p = Option.map Lwt_bytes.to_string ps in
                 Lwt_io.printlf "got p = %s" ([%show : string option] p) >>= fun () ->
                 assert (presence = (p <> None));
                 let fragment_key = wrap_string
@@ -308,7 +308,7 @@ let test_delete_namespace () =
                                      )
                 in
                 c # get_option Osd.High fragment_key >>= fun fs ->
-                let f = Option.map Bigstring_slice.to_string fs in
+                let f = Option.map Lwt_bytes.to_string fs in
                 Lwt_io.printlf "got f = %s" ([%show : string option] f) >>= fun () ->
                 assert (fragment = (f <> None));
                 Lwt.return ()) in

--- a/ocaml/src/asd_client.ml
+++ b/ocaml/src/asd_client.ml
@@ -41,7 +41,7 @@ class client fd id =
           Lwt_log.debug_f "Exception in asd_client %s: %s" id (show err') >>= fun () ->
           lwt_fail err')
       (fun () ->
-       Lwt_bytes.unsafe_destroy res_buf;
+       (* Lwt_bytes.unsafe_destroy res_buf; *)
        Lwt.return_unit)
   in
   let do_request

--- a/ocaml/src/asd_io_scheduler.ml
+++ b/ocaml/src/asd_io_scheduler.ml
@@ -23,7 +23,7 @@ type 'a io = unit -> ('a * int) Lwt.t
 
 type 'a io_with_waiter = 'a Lwt.u * 'a io
 type output = unit  io_with_waiter
-type input  = (bytes * (Lwt_unix.file_descr -> unit Lwt.t)) io_with_waiter
+type input  = (Llio2.WriteBuffer.t * (Lwt_unix.file_descr -> unit Lwt.t)) io_with_waiter
 
 type t = {
     high_prio_reads  : input  Lwt_buffer.t;

--- a/ocaml/src/asd_protocol.ml
+++ b/ocaml/src/asd_protocol.ml
@@ -74,7 +74,7 @@ module Value = struct
     Checksum.output buf cs
   let to_buffer' buf (blob, cs) =
     blob_to_buffer' buf blob;
-    Checksum.to_buffer' buf cs
+    Checksum_deser.to_buffer' buf cs
 
   let from_buffer buf =
     let blob = blob_from_buffer buf in
@@ -82,7 +82,7 @@ module Value = struct
     (blob, cs)
   let from_buffer' buf =
     let blob = blob_from_buffer' buf in
-    let cs = Checksum.from_buffer' buf in
+    let cs = Checksum_deser.from_buffer' buf in
     (blob, cs)
 end
 
@@ -186,7 +186,7 @@ module Update = struct
       Llio.option_to
         (Llio.tuple3_to
            Slice.to_buffer'
-           Checksum.to_buffer'
+           Checksum_deser.to_buffer'
            Llio.bool_to
         )
         buf
@@ -216,7 +216,7 @@ module Update = struct
         Llio.option_from
           (Llio.tuple3_from
              Slice.from_buffer'
-             Checksum.from_buffer'
+             Checksum_deser.from_buffer'
              Llio.bool_from
           )
           buf
@@ -540,12 +540,12 @@ module Protocol = struct
           (Llio.tuple3_to
              Slice.to_buffer'
              Slice.to_buffer'
-             Checksum.to_buffer')
+             Checksum_deser.to_buffer')
       | MultiGet ->
          Llio.list_to (Llio.option_to
                          (Llio.pair_to
                             Slice.to_buffer'
-                            Checksum.to_buffer'
+                            Checksum_deser.to_buffer'
                          )
                       )
       | MultiGet2 ->
@@ -573,12 +573,12 @@ module Protocol = struct
           (Llio.tuple3_from
              Slice.from_buffer'
              Slice.from_buffer'
-             Checksum.from_buffer')
+             Checksum_deser.from_buffer')
       | MultiGet -> Llio.list_from
                       (Llio.option_from
                          (Llio.pair_from
                             Slice.from_buffer'
-                            Checksum.from_buffer'
+                            Checksum_deser.from_buffer'
                          )
                       )
       | MultiGet2 ->

--- a/ocaml/src/asd_statistics.ml
+++ b/ocaml/src/asd_statistics.ml
@@ -28,17 +28,18 @@ module AsdStatistics = struct
 
     let snapshot t reset = G.snapshot t reset
 
-    let from_buffer buf =
+    let from_buffer' buf =
+      let module Llio = Llio2.ReadBuffer in
       let ser_version = Llio.int8_from buf in
       match ser_version with
       | 1 ->
          begin
           let creation  = Llio.float_from buf in
           let period    = Llio.float_from buf in
-          let multi_get = Stat.stat_from buf in
-          let range = Stat.stat_from buf in
-          let range_entries = Stat.stat_from buf in
-          let apply = Stat.stat_from buf in
+          let multi_get = Stat.from_buffer' buf in
+          let range = Stat.from_buffer' buf in
+          let range_entries = Stat.from_buffer' buf in
+          let apply = Stat.from_buffer' buf in
           let statistics = Hashtbl.create 16 in
           let () = List.iter
             (fun (c,stat) ->
@@ -56,10 +57,10 @@ module AsdStatistics = struct
               G.statistics
           }
          end
-      | 2 -> Statistics_collection.Generic.from_buffer_raw buf
+      | 2 -> Statistics_collection.Generic.from_buffer_raw' buf
       | k -> Prelude.raise_bad_tag "AsdStatistics" k
 
-    let to_buffer buf t =
-      Statistics_collection.Generic.to_buffer_with_version ~ser_version:2 buf t
+    let to_buffer' buf t =
+      Statistics_collection.Generic.to_buffer_with_version' ~ser_version:2 buf t
 
 end

--- a/ocaml/src/asd_statistics.ml
+++ b/ocaml/src/asd_statistics.ml
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *)
 
-open Stat
-
 module AsdStatistics = struct
     module G = Statistics_collection.Generic
     type t = G.t
@@ -36,10 +34,10 @@ module AsdStatistics = struct
          begin
           let creation  = Llio.float_from buf in
           let period    = Llio.float_from buf in
-          let multi_get = Stat.from_buffer' buf in
-          let range = Stat.from_buffer' buf in
-          let range_entries = Stat.from_buffer' buf in
-          let apply = Stat.from_buffer' buf in
+          let multi_get = Stat_deser.from_buffer' buf in
+          let range = Stat_deser.from_buffer' buf in
+          let range_entries = Stat_deser.from_buffer' buf in
+          let apply = Stat_deser.from_buffer' buf in
           let statistics = Hashtbl.create 16 in
           let () = List.iter
             (fun (c,stat) ->
@@ -57,10 +55,10 @@ module AsdStatistics = struct
               G.statistics
           }
          end
-      | 2 -> Statistics_collection.Generic.from_buffer_raw' buf
+      | 2 -> Statistics_collection_deser.from_buffer_raw' buf
       | k -> Prelude.raise_bad_tag "AsdStatistics" k
 
     let to_buffer' buf t =
-      Statistics_collection.Generic.to_buffer_with_version' ~ser_version:2 buf t
+      Statistics_collection_deser.to_buffer_with_version' ~ser_version:2 buf t
 
 end

--- a/ocaml/src/asd_test.ml
+++ b/ocaml/src/asd_test.ml
@@ -242,14 +242,14 @@ let test_protocol_version port () =
   let protocol_test port =
     Lwt.catch
       (fun () ->
-       Networking2.first_connection' buffer_pool ["127.0.0.1"] port
-       >>= fun (_, (ic,oc), closer) ->
+       Networking2.first_connection ["127.0.0.1"] port
+       >>= fun (fd, closer) ->
        Lwt.finalize
          (fun () ->
           let prologue_bytes = Asd_client.make_prologue
                                  Asd_protocol._MAGIC 666l None in
-          Lwt_io.write oc prologue_bytes >>= fun () ->
-          Asd_client._prologue_response ic None >>= fun _ ->
+          Lwt_extra2.write_all' fd prologue_bytes >>= fun () ->
+          Asd_client._prologue_response fd None >>= fun _ ->
           OUnit.assert_bool "should have failed" false;
           Lwt.return ())
          closer

--- a/ocaml/src/cli_asd.ml
+++ b/ocaml/src/cli_asd.ml
@@ -158,7 +158,7 @@ let asd_set host port asd_id key value =
      client # apply_sequence ~prio:Osd.High []
              [ Update.set
                  (Slice.wrap_string key)
-                 (Slice.wrap_string value)
+                 (Osd.Blob.Bytes value)
                  checksum true
              ]
     )
@@ -203,7 +203,7 @@ let asd_multi_get host port asd_id (keys:string list) =
 
      client # multi_get ~prio:Osd.High (List.map Slice.wrap_string keys)
      >>= fun values ->
-     print_endline ([%show: (Slice.t * Checksum.t) option list] values);
+     print_endline ([%show: (Bigstring_slice.t * Checksum.t) option list] values);
      Lwt.return ())
 
 let asd_multi_get_cmd =

--- a/ocaml/src/kinetic_client.ml
+++ b/ocaml/src/kinetic_client.ml
@@ -201,7 +201,7 @@ class kinetic_client cid session conn =
       match vco with
       | None -> Lwt.return None
       | Some (v, version) ->
-         let vo_s = Some (Bigstring_slice.wrap_bigstring (Lwt_bytes.of_string v)) in
+         let vo_s = Some (Lwt_bytes.of_string v) in
          Lwt.return vo_s
 
 

--- a/ocaml/src/maintenance.ml
+++ b/ocaml/src/maintenance.ml
@@ -18,6 +18,7 @@ open Prelude
 open Slice
 open Recovery_info
 open Lwt.Infix
+open Lwt_bytes2
 
 
 let gc_grace_period = Nsm_host_access.gc_grace_period
@@ -296,24 +297,29 @@ class client ?(retry_timeout = 60.)
          | Prelude.Error.Error x ->
             Lwt.fail (Exn NotEnoughFragments)
          | Prelude.Error.Ok (_, _, packed_fragment) ->
-            Fragment_helper.verify packed_fragment fragment_checksum
-            >>= fun checksum_valid ->
-            if not checksum_valid
-            then Lwt.fail (Exn ChecksumMismatch)
-            else
-              begin
-                Alba_client_upload.upload_packed_fragment_data
-                  (alba_client # osd_access)
-                  ~namespace_id ~object_id
-                  ~chunk_id ~fragment_id ~version_id:version_id1
-                  ~packed_fragment:(Bigstring_slice.wrap_bigstring packed_fragment)
-                  ~checksum:fragment_checksum
-                  ~gc_epoch
-                  ~recovery_info_blob:(Osd.Blob.Slice recovery_info_slice)
-                  ~osd_id:target_osd
-                >>= fun () ->
-                Lwt.return (chunk_id, fragment_id, source_osd, target_osd)
-              end
+            Lwt.finalize
+              (fun () ->
+               Fragment_helper.verify packed_fragment fragment_checksum
+               >>= fun checksum_valid ->
+               if not checksum_valid
+               then Lwt.fail (Exn ChecksumMismatch)
+               else
+                 begin
+                   Alba_client_upload.upload_packed_fragment_data
+                     (alba_client # osd_access)
+                     ~namespace_id ~object_id
+                     ~chunk_id ~fragment_id ~version_id:version_id1
+                     ~packed_fragment:(Bigstring_slice.wrap_bigstring packed_fragment)
+                     ~checksum:fragment_checksum
+                     ~gc_epoch
+                     ~recovery_info_blob:(Osd.Blob.Slice recovery_info_slice)
+                     ~osd_id:target_osd
+                   >>= fun () ->
+                   Lwt.return (chunk_id, fragment_id, source_osd, target_osd)
+                 end)
+              (fun () ->
+               Lwt_bytes.unsafe_destroy packed_fragment;
+               Lwt.return_unit)
          )
         (List.mapi (fun i lc -> i, lc) fragment_info)
       >>= fun object_location_movements ->

--- a/ocaml/src/maintenance.ml
+++ b/ocaml/src/maintenance.ml
@@ -306,7 +306,8 @@ class client ?(retry_timeout = 60.)
                   (alba_client # osd_access)
                   ~namespace_id ~object_id
                   ~chunk_id ~fragment_id ~version_id:version_id1
-                  ~packed_fragment ~checksum:fragment_checksum
+                  ~packed_fragment:(Bigstring_slice.wrap_bigstring packed_fragment)
+                  ~checksum:fragment_checksum
                   ~gc_epoch
                   ~recovery_info_blob:(Osd.Blob.Slice recovery_info_slice)
                   ~osd_id:target_osd

--- a/ocaml/src/maintenance.ml
+++ b/ocaml/src/maintenance.ml
@@ -296,7 +296,7 @@ class client ?(retry_timeout = 60.)
          | Prelude.Error.Error x ->
             Lwt.fail (Exn NotEnoughFragments)
          | Prelude.Error.Ok (_, _, packed_fragment) ->
-            Fragment_helper.verify' packed_fragment fragment_checksum
+            Fragment_helper.verify packed_fragment fragment_checksum
             >>= fun checksum_valid ->
             if not checksum_valid
             then Lwt.fail (Exn ChecksumMismatch)
@@ -308,7 +308,7 @@ class client ?(retry_timeout = 60.)
                   ~chunk_id ~fragment_id ~version_id:version_id1
                   ~packed_fragment ~checksum:fragment_checksum
                   ~gc_epoch
-                  ~recovery_info_slice
+                  ~recovery_info_blob:(Osd.Blob.Slice recovery_info_slice)
                   ~osd_id:target_osd
                 >>= fun () ->
                 Lwt.return (chunk_id, fragment_id, source_osd, target_osd)
@@ -626,7 +626,9 @@ class client ?(retry_timeout = 60.)
                       retag fragments strategy is applied (when an upload
                       failed due to Invalid_gc_epoch) we're not removing
                       a value that could still be used for some object... *)
-                   Osd.Assert.value gc_tag_key (wrap_string ""); ] in
+                   Osd.Assert.value
+                     gc_tag_key
+                     (Osd.Blob.Bytes ""); ] in
 
                Lwt_log.debug_f
                  "Cleaning up garbage fragment ns_id=%li, gc_epoch=%Li, object_id=%S, %i,%i,%i"

--- a/ocaml/src/maintenance_helper.ml
+++ b/ocaml/src/maintenance_helper.ml
@@ -15,7 +15,6 @@ limitations under the License.
 *)
 
 open Prelude
-open Slice
 open Nsm_model
 open Recovery_info
 open Lwt.Infix
@@ -124,8 +123,7 @@ let upload_missing_fragments
        compression
        encryption
        fragment_checksum_algo
-     >>= fun (packed_fragment_bs, _, _, checksum') ->
-     let packed_fragment = Slice.of_bigstring packed_fragment_bs in
+     >>= fun (packed_fragment, _, _, checksum') ->
 
      if checksum = checksum'
      then
@@ -138,7 +136,8 @@ let upload_missing_fragments
            ~chunk_id ~fragment_id
            ~packed_fragment
            ~gc_epoch ~checksum
-           ~recovery_info_slice >>= fun () ->
+           ~recovery_info_blob:(Osd.Blob.Slice recovery_info_slice)
+         >>= fun () ->
          Lwt.return (fragment_id, chosen_osd_id)
        end
      else

--- a/ocaml/src/osd.ml
+++ b/ocaml/src/osd.ml
@@ -17,7 +17,7 @@ limitations under the License.
 open Prelude
 
 type key = Asd_protocol.key
-type value = Asd_protocol.value
+type value = Lwt_bytes.t
 type checksum = Asd_protocol.checksum
 
 type priority = Asd_protocol.Protocol.priority =

--- a/ocaml/src/osd.ml
+++ b/ocaml/src/osd.ml
@@ -24,6 +24,7 @@ type priority = Asd_protocol.Protocol.priority =
               | High
               | Low
 
+module Blob = Asd_protocol.Blob
 module Update = Asd_protocol.Update
 module Assert = Asd_protocol.Assert
 

--- a/ocaml/src/osd_access.ml
+++ b/ocaml/src/osd_access.ml
@@ -469,7 +469,7 @@ class osd_access
                                closer >>= function
                              | None -> Lwt.return `Continue
                              | Some alba_id' ->
-                                let alba_id' = Slice.get_string_unsafe alba_id' in
+                                let alba_id' = Bigstring_slice.to_string alba_id' in
                                 mgr_access # get_alba_id >>= fun alba_id ->
 
                                 Lwt.catch

--- a/ocaml/src/osd_access.ml
+++ b/ocaml/src/osd_access.ml
@@ -469,7 +469,7 @@ class osd_access
                                closer >>= function
                              | None -> Lwt.return `Continue
                              | Some alba_id' ->
-                                let alba_id' = Bigstring_slice.to_string alba_id' in
+                                let alba_id' = Lwt_bytes.to_string alba_id' in
                                 mgr_access # get_alba_id >>= fun alba_id ->
 
                                 Lwt.catch

--- a/ocaml/src/osd_bench.ml
+++ b/ocaml/src/osd_bench.ml
@@ -47,7 +47,7 @@ let gets (client: Osd.osd) progress n value_size period prefix =
     let () =
       match _value with
       | None   -> failwith (Printf.sprintf "db[%s] = None?" key)
-      | Some v -> assert (Bigstring_slice.length v = value_size)
+      | Some v -> assert (Lwt_bytes.length v = value_size)
     in
     Lwt.return ()
   in

--- a/ocaml/src/osd_bench.ml
+++ b/ocaml/src/osd_bench.ml
@@ -47,7 +47,7 @@ let gets (client: Osd.osd) progress n value_size period prefix =
     let () =
       match _value with
       | None   -> failwith (Printf.sprintf "db[%s] = None?" key)
-      | Some v -> assert (v.Slice.length = value_size)
+      | Some v -> assert (Bigstring_slice.length v = value_size)
     in
     Lwt.return ()
   in
@@ -73,10 +73,11 @@ let sets (client:Osd.osd) progress n value_size period prefix =
   let do_one i =
     let key = gen () in
     let key_slice = Slice.wrap_string key in
-    let value_slice = Slice.wrap_string value in
     let open Checksum in
     let set = Update.Set (key_slice,
-                          Some (value_slice, Checksum.NoChecksum, false))
+                          Some (Blob.Bytes value,
+                                Checksum.NoChecksum,
+                                false))
 
     in
     let updates = [set] in

--- a/ocaml/src/recover_nsm_host.ml
+++ b/ocaml/src/recover_nsm_host.ml
@@ -187,7 +187,7 @@ let reap_osd
                 let recovery_info =
                   deserialize
                     RecoveryInfo.from_buffer
-                    (Slice.get_string_unsafe v) in
+                    (Bigstring_slice.to_string v) in
 
                 WriteBatch.put
                   wb

--- a/ocaml/src/recover_nsm_host.ml
+++ b/ocaml/src/recover_nsm_host.ml
@@ -187,7 +187,7 @@ let reap_osd
                 let recovery_info =
                   deserialize
                     RecoveryInfo.from_buffer
-                    (Bigstring_slice.to_string v) in
+                    (Lwt_bytes.to_string v) in
 
                 WriteBatch.put
                   wb

--- a/ocaml/src/recovery_info.ml
+++ b/ocaml/src/recovery_info.ml
@@ -122,7 +122,7 @@ module RecoveryInfo = struct
       encryption
       ~object_id
       ~chunk_id:(-1) ~fragment_id:(-1) ~ignore_fragment_id:false
-      (Bigstring_slice.of_string t.payload) >>= fun decrypted ->
+      (Lwt_bytes.of_string t.payload) >>= fun decrypted ->
     let t' =
       Compressors.Bzip2.decompress_bs_string decrypted |>
       deserialize from_buffer'

--- a/ocaml/src/recovery_info.ml
+++ b/ocaml/src/recovery_info.ml
@@ -100,14 +100,15 @@ module RecoveryInfo = struct
 
   let t'_to_t t' encryption ~object_id =
     let open Lwt.Infix in
-    serialize to_buffer' t' |>
-    Compressors.Bzip2.compress_string_to_ba |>
-    Fragment_helper.maybe_encrypt
-      encryption
-      ~object_id
-      ~chunk_id:(-1) ~fragment_id:(-1) ~ignore_fragment_id:false
+    serialize to_buffer' t'
+    |> Compressors.Bzip2.compress_string_to_ba
+    |> Bigstring_slice.wrap_bigstring
+    |> Fragment_helper.maybe_encrypt
+         encryption
+         ~object_id
+         ~chunk_id:(-1) ~fragment_id:(-1) ~ignore_fragment_id:false
     >>= fun encrypted ->
-    let payload = Lwt_bytes.to_string encrypted in
+    let payload = Bigstring_slice.to_string encrypted in
     let encrypt_info = EncryptInfo.from_encryption encryption in
     Lwt.return { payload; encrypt_info; }
 
@@ -121,9 +122,9 @@ module RecoveryInfo = struct
       encryption
       ~object_id
       ~chunk_id:(-1) ~fragment_id:(-1) ~ignore_fragment_id:false
-      (Lwt_bytes.of_string t.payload) >>= fun decrypted ->
+      (Bigstring_slice.of_string t.payload) >>= fun decrypted ->
     let t' =
-      Compressors.Bzip2.decompress_ba_string decrypted |>
+      Compressors.Bzip2.decompress_bs_string decrypted |>
       deserialize from_buffer'
     in
     Lwt.return t'

--- a/ocaml/src/sync_bench.ml
+++ b/ocaml/src/sync_bench.ml
@@ -19,8 +19,7 @@ open Asd_server
 open Stat
 let batch_entry_syncfs dir_info fnr data size =
   let t () =
-    let open Slice in
-    let blob = Slice.make data 0 size in
+    let blob = Osd.Blob.Bytes data in
     DirectoryInfo.write_blob dir_info fnr blob >>= fun () ->
     Lwt.return ()
   in

--- a/ocaml/src/tools/bigstring_slice.ml
+++ b/ocaml/src/tools/bigstring_slice.ml
@@ -20,6 +20,13 @@ type t = {
   length : int;
 }
 
+let show t =
+  (* TODO this could be better. *)
+  String.escaped (Lwt_bytes.to_string t.bs)
+
+let pp formatter t =
+  Format.pp_print_string formatter (show t)
+
 let from_bigstring bs offset length =
   { bs; offset; length; }
 

--- a/ocaml/src/tools/bigstring_slice.ml
+++ b/ocaml/src/tools/bigstring_slice.ml
@@ -20,9 +20,9 @@ type t = {
   length : int;
 }
 
-let show t =
-  (* TODO this could be better. *)
-  String.escaped (Lwt_bytes.to_string t.bs)
+let show =
+  let r = "<bigstring_slice>" in
+  fun t -> r
 
 let pp formatter t =
   Format.pp_print_string formatter (show t)
@@ -48,3 +48,13 @@ let extract t offset length =
   wrap_bigstring bs
 
 let length t = t.length
+
+let get t pos = Lwt_bytes.get t.bs (t.offset + pos)
+
+let to_string t =
+  let s = Bytes.create t.length in
+  Lwt_bytes.blit_to_bytes t.bs t.offset s 0 t.length;
+  s
+
+let of_string s =
+  Lwt_bytes.of_string s |> wrap_bigstring

--- a/ocaml/src/tools/bigstring_slice.ml
+++ b/ocaml/src/tools/bigstring_slice.ml
@@ -28,6 +28,7 @@ let pp formatter t =
   Format.pp_print_string formatter (show t)
 
 let from_bigstring bs offset length =
+  assert (offset + length <= Lwt_bytes.length bs);
   { bs; offset; length; }
 
 let wrap_bigstring bs =

--- a/ocaml/src/tools/checksum.ml
+++ b/ocaml/src/tools/checksum.ml
@@ -55,32 +55,8 @@ module Checksum = struct
     | Crc32c d ->
       Llio.int8_to buf 3;
       Llio.int32_to buf d
-  let to_buffer' buf =
-    let module Llio = Llio2.WriteBuffer in
-    function
-    | NoChecksum ->
-      Llio.int8_to buf 1
-    | Sha1 d ->
-      Llio.int8_to buf 2;
-      assert (String.length d = 20);
-      Llio.string_to buf d
-    | Crc32c d ->
-      Llio.int8_to buf 3;
-      Llio.int32_to buf d
 
   let input buf =
-    match Llio.int8_from buf with
-    | 1 -> NoChecksum
-    | 2 ->
-      let d = Llio.string_from buf in
-      assert(String.length d = 20);
-      Sha1 d
-    | 3 ->
-      let d = Llio.int32_from buf in
-      Crc32c d
-    | k -> Prelude.raise_bad_tag "checksum" k
-  let from_buffer' buf =
-    let module Llio = Llio2.ReadBuffer in
     match Llio.int8_from buf with
     | 1 -> NoChecksum
     | 2 ->

--- a/ocaml/src/tools/checksum.ml
+++ b/ocaml/src/tools/checksum.ml
@@ -55,8 +55,32 @@ module Checksum = struct
     | Crc32c d ->
       Llio.int8_to buf 3;
       Llio.int32_to buf d
+  let to_buffer' buf =
+    let module Llio = Llio2.WriteBuffer in
+    function
+    | NoChecksum ->
+      Llio.int8_to buf 1
+    | Sha1 d ->
+      Llio.int8_to buf 2;
+      assert (String.length d = 20);
+      Llio.string_to buf d
+    | Crc32c d ->
+      Llio.int8_to buf 3;
+      Llio.int32_to buf d
 
   let input buf =
+    match Llio.int8_from buf with
+    | 1 -> NoChecksum
+    | 2 ->
+      let d = Llio.string_from buf in
+      assert(String.length d = 20);
+      Sha1 d
+    | 3 ->
+      let d = Llio.int32_from buf in
+      Crc32c d
+    | k -> Prelude.raise_bad_tag "checksum" k
+  let from_buffer' buf =
+    let module Llio = Llio2.ReadBuffer in
     match Llio.int8_from buf with
     | 1 -> NoChecksum
     | 2 ->

--- a/ocaml/src/tools/checksum_deser.ml
+++ b/ocaml/src/tools/checksum_deser.ml
@@ -1,0 +1,43 @@
+(*
+Copyright 2015 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Checksum.Checksum
+
+let to_buffer' buf =
+  let module Llio = Llio2.WriteBuffer in
+  function
+  | NoChecksum ->
+     Llio.int8_to buf 1
+  | Sha1 d ->
+     Llio.int8_to buf 2;
+     assert (String.length d = 20);
+     Llio.string_to buf d
+  | Crc32c d ->
+     Llio.int8_to buf 3;
+     Llio.int32_to buf d
+
+let from_buffer' buf =
+  let module Llio = Llio2.ReadBuffer in
+  match Llio.int8_from buf with
+  | 1 -> NoChecksum
+  | 2 ->
+     let d = Llio.string_from buf in
+     assert(String.length d = 20);
+     Sha1 d
+  | 3 ->
+     let d = Llio.int32_from buf in
+     Crc32c d
+  | k -> Prelude.raise_bad_tag "checksum" k

--- a/ocaml/src/tools/compressors.ml
+++ b/ocaml/src/tools/compressors.ml
@@ -393,6 +393,7 @@ let decompress c f =
   (* bigstring_slice to big array, detached *)
   match c with
   | NoCompression ->
+     (* TODO can eliminate a copy here if the bigstring is exactly the desired lwt_bytes *)
      let res = Bigstring_slice.extract_to_bigstring f in
      Lwt_bytes.unsafe_destroy f.Bigstring_slice.bs;
      Lwt.return res

--- a/ocaml/src/tools/gcrypt.ml
+++ b/ocaml/src/tools/gcrypt.ml
@@ -125,21 +125,21 @@ module Padding = struct
     res
 
   let unpad data =
-    (* unpad from Bigstring_slice to Bigstring_slice (in place) *)
-    let open Bigstring_slice in
-    let len = length data in
-    let cnt_char = get data (len - 1) in
+    (* unpad from Lwt_bytes to Bigstring_slice (in place) *)
+    let len = Lwt_bytes.length data in
+    let cnt_char = Lwt_bytes.get data (len - 1) in
     let cnt = Char.code cnt_char in
     if cnt = 0 || cnt > len then failwith "bad padding";
 
     for i = len - cnt to len - 1 do
-      if cnt_char <> get data i
+      if cnt_char <> Lwt_bytes.get data i
       then failwith "bad padding'"
     done;
 
-    { bs = data.bs;
-      offset = data.offset;
-      length = len - cnt; }
+    Bigstring_slice.from_bigstring
+      data
+      0
+      (len - cnt)
 
 end
 

--- a/ocaml/src/tools/gcrypt.ml
+++ b/ocaml/src/tools/gcrypt.ml
@@ -113,34 +113,33 @@ let () =
 module Padding = struct
 
   let pad data block_len =
-    (* pad from bigarray to bigarray *)
-    let used_len = Lwt_bytes.length data in
+    (* pad from Bigstring_slice.t to bigarray *)
+    let used_len = Bigstring_slice.length data in
     let pad_len = (used_len/block_len + 1) * block_len in
     let res = Lwt_bytes.create pad_len in
-    Lwt_bytes.blit data 0 res 0 used_len;
+    (let open Bigstring_slice in
+     Lwt_bytes.blit data.bs data.offset res 0 used_len);
     let n = pad_len - used_len in
     assert (n > 0 && n <= block_len);
     Lwt_bytes.fill res used_len n (Char.chr n);
     res
 
-  let unpad ~release_input data =
-    (* unpad from bigarray to bigarray (in place) *)
-    let len = Lwt_bytes.length data in
-    let cnt_char = Lwt_bytes.get data (len - 1) in
+  let unpad data =
+    (* unpad from Bigstring_slice to Bigstring_slice (in place) *)
+    let open Bigstring_slice in
+    let len = length data in
+    let cnt_char = get data (len - 1) in
     let cnt = Char.code cnt_char in
     if cnt = 0 || cnt > len then failwith "bad padding";
 
     for i = len - cnt to len - 1 do
-      if cnt_char <> Lwt_bytes.get data i
+      if cnt_char <> get data i
       then failwith "bad padding'"
     done;
 
-    let res = Lwt_bytes.extract data 0 (len - cnt) in
-
-    if release_input
-    then Lwt_bytes.unsafe_destroy data;
-
-    res
+    { bs = data.bs;
+      offset = data.offset;
+      length = len - cnt; }
 
 end
 
@@ -351,15 +350,14 @@ module Cipher = struct
          ptr char @-> int_to_size_t @->
          returning Error.t)
     in
-    fun t ?iv data ->
+    fun t ?iv (data : Lwt_bytes.t) offset length ->
       Option.iter (fun iv -> set_iv t iv) iv;
-      let len = Lwt_bytes.length data in
       let open Lwt.Infix in
       Lwt_preemptive.detach
         (fun () ->
            inner
              t
-             (bigarray_start array1 data) len
+             (bigarray_start array1 data +@ offset) length
              (from_voidp char null) 0)
         ()
       >>= fun err ->

--- a/ocaml/src/tools/gcrypt_test.ml
+++ b/ocaml/src/tools/gcrypt_test.ml
@@ -24,7 +24,7 @@ let test_encrypt_decrypt () =
     let block_len = 16 in
     let key = String.make 32 'a' in
     let get_res () =
-      let padded_data = Padding.pad (Lwt_bytes.of_string data) block_len in
+      let padded_data = Padding.pad (Bigstring_slice.of_string data) block_len in
       Cipher.with_t_lwt
         key Cipher.AES256 Cipher.CBC []
         (fun cipher ->
@@ -43,9 +43,11 @@ let test_encrypt_decrypt () =
       (fun cipher ->
          Cipher.decrypt
            cipher
-           res1) >>= fun () ->
-    let data' = Padding.unpad ~release_input:false res1 in
-    OUnit.assert_equal (Lwt_bytes.to_string data') data;
+           res1
+           0
+           (Lwt_bytes.length res1)) >>= fun () ->
+    let data' = Padding.unpad (Bigstring_slice.wrap_bigstring res1) in
+    OUnit.assert_equal (Bigstring_slice.to_string data') data;
     Lwt.return ()
   in
   Lwt_main.run (t ())

--- a/ocaml/src/tools/gcrypt_test.ml
+++ b/ocaml/src/tools/gcrypt_test.ml
@@ -46,7 +46,7 @@ let test_encrypt_decrypt () =
            res1
            0
            (Lwt_bytes.length res1)) >>= fun () ->
-    let data' = Padding.unpad (Bigstring_slice.wrap_bigstring res1) in
+    let data' = Padding.unpad res1 in
     OUnit.assert_equal (Bigstring_slice.to_string data') data;
     Lwt.return ()
   in

--- a/ocaml/src/tools/llio2.ml
+++ b/ocaml/src/tools/llio2.ml
@@ -1,0 +1,318 @@
+(*
+Copyright 2015 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Prelude
+open Lwt_bytes2
+
+module ReadBuffer = struct
+    type t = { buf : Lwt_bytes.t;
+               mutable pos : int; }
+
+    type 'a deserializer = t -> 'a
+
+    let make_buffer buf pos = { buf; pos; }
+
+    let advance_pos buf delta = buf.pos <- buf.pos + delta
+
+    let buffer_done buf = buf.pos = Lwt_bytes.length buf.buf
+
+    let unit_from buf = ()
+
+    let maybe_from_buffer a_from default buf =
+      if buffer_done buf
+      then default
+      else
+        let res = a_from buf in
+        assert (buffer_done buf);
+        res
+
+    let pair_from a_from b_from buf =
+      let a = a_from buf in
+      let b = b_from buf in
+      (a, b)
+    let tuple3_from a_from b_from c_from buf =
+      let a = a_from buf in
+      let b = b_from buf in
+      let c = c_from buf in
+      (a, b, c)
+    let tuple4_from a_from b_from c_from d_from buf =
+      let a = a_from buf in
+      let b = b_from buf in
+      let c = c_from buf in
+      let d = d_from buf in
+      (a, b, c, d)
+
+    let int32_from buf =
+      let r = get32_prim' buf.buf buf.pos in
+      advance_pos buf 4;
+      r
+
+    let int64_from buf =
+      let r = get64_prim' buf.buf buf.pos in
+      advance_pos buf 8;
+      r
+
+    let float_from buf =
+      int64_from buf |> Int64.float_of_bits
+
+    let int_from buf = int32_from buf |> Int32.to_int
+
+    let char_from buf =
+      let r = Lwt_bytes.get buf.buf buf.pos in
+      advance_pos buf 1;
+      r
+
+    let int8_from buf =
+      Char.code (char_from buf)
+
+    let bool_from buf =
+      match char_from buf with
+      | '\x00' -> false
+      | '\x01' -> true
+      | k -> raise_bad_tag "bool" (Char.code k)
+
+    let option_from a_from buf =
+      match bool_from buf with
+      | false -> None
+      | true -> Some (a_from buf)
+
+    let string_from buf =
+      let len = int_from buf in
+      let bs = Bytes.create len in
+      Lwt_bytes.blit_to_bytes buf.buf buf.pos bs 0 len;
+      advance_pos buf len;
+      bs
+
+    let bigstring_slice_from : Bigstring_slice.t deserializer =
+      fun buf ->
+      let len = int_from buf in
+      let r = Bigstring_slice.from_bigstring buf.buf buf.pos len in
+      advance_pos buf len;
+      r
+
+    let counted_list_from e_from buf =
+      let size = int_from buf in
+      let rec loop acc = function
+        | 0 -> acc
+        | i -> let e = e_from buf in
+               loop (e::acc) (i-1)
+      in
+      size, (loop [] size)
+
+    let counted_list_more_from e_from =
+      pair_from
+        (counted_list_from e_from)
+        bool_from
+
+    let list_from e_from buf = counted_list_from e_from buf |> snd
+
+    let hashtbl_from kv_from buf =
+      let len = int_from buf in
+      let r = Hashtbl.create len in
+      let rec loop = function
+        | 0 -> r
+        | i -> let (k,v) = kv_from buf in
+               let () = Hashtbl.add r k v in
+               loop (i-1)
+      in
+      loop len
+  end
+
+module WriteBuffer = struct
+    type t = { mutable buf : Lwt_bytes.t;
+               mutable pos : int; }
+
+    let make ~length =
+      { buf = Lwt_bytes.create length;
+        pos = 0; }
+
+    type 'a serializer = t -> 'a -> unit
+
+    let ensure_space buf delta =
+      let pos = buf.pos in
+      let len = Lwt_bytes.length buf.buf in
+      if pos + delta > len
+      then
+        begin
+          let newbuf = Lwt_bytes.create (max (len + delta) (2*len)) in
+          let oldbuf = buf.buf in
+          Lwt_bytes.blit oldbuf 0 newbuf 0 pos;
+          buf.buf <- newbuf;
+          Lwt_bytes.unsafe_destroy oldbuf
+        end
+
+    let advance_pos buf delta =
+      buf.pos <- buf.pos + delta
+
+    let with_ buf delta f =
+      ensure_space buf delta;
+      f ();
+      advance_pos buf delta
+
+    let unit_to buf () = ()
+
+    let pair_to a_to b_to buf (a, b) =
+      a_to buf a;
+      b_to buf b
+    let tuple3_to a_to b_to c_to buf (a, b, c) =
+      a_to buf a;
+      b_to buf b;
+      c_to buf c
+    let tuple4_to a_to b_to c_to d_to buf (a, b, c, d) =
+      a_to buf a;
+      b_to buf b;
+      c_to buf c;
+      d_to buf d
+
+    let int32_to buf i =
+      with_ buf 4
+            (fun () -> set32_prim' buf.buf buf.pos i)
+
+    let int64_to buf i =
+      with_ buf 8
+            (fun () -> set64_prim' buf.buf buf.pos i)
+
+    let float_to buf f =
+      int64_to buf (Int64.bits_of_float f)
+
+    let int_to buf i = int32_to buf (Int32.of_int i)
+
+    let char_to buf c =
+      with_ buf 1
+            (fun () -> Lwt_bytes.set buf.buf buf.pos c)
+
+    let int8_to buf i =
+      char_to buf (Char.chr i)
+
+    let bool_to buf b =
+      char_to buf (if b
+                   then '\x01'
+                   else '\x00')
+
+    let option_to a_to buf = function
+      | None -> bool_to buf false
+      | Some a -> bool_to buf true;
+                  a_to buf a
+
+    let raw_substring_to buf (s, offset, length) =
+      with_ buf length
+            (fun () -> Lwt_bytes.blit_from_bytes s offset buf.buf buf.pos length)
+
+    let raw_string_to buf s =
+      raw_substring_to buf (s, 0, String.length s)
+
+    let substring_to buf ((s, offset, length) as ss) =
+      ensure_space buf (length + 4);
+      int_to buf length;
+      raw_substring_to buf ss
+
+    let string_to buf s =
+      substring_to buf (s, 0, String.length s)
+
+    let bigstring_slice_to : Bigstring_slice.t serializer =
+      fun buf bss ->
+      let open Bigstring_slice in
+      ensure_space buf (bss.length + 4);
+      int_to buf bss.length;
+      Lwt_bytes.blit bss.bs bss.offset buf.buf buf.pos bss.length;
+      advance_pos buf bss.length
+
+    let counted_list_to e_to buf (cnt, list) =
+      int_to buf cnt;
+      List.iter (e_to buf) (List.rev list)
+
+    let counted_list_more_to a_to =
+      pair_to
+        (counted_list_to a_to)
+        bool_to
+
+    let list_to e_to buf list =
+      (* TODO ideally the list should be iterated only once *)
+      counted_list_to e_to buf (List.length list, list)
+
+    let serialize_with_length ?(length = 20) a_to a =
+      let buf = make ~length in
+      int_to buf 0;
+      a_to buf a;
+      let len = buf.pos - 4 in
+      set32_prim' buf.buf 0 (Int32.of_int len);
+      buf
+
+    let hashtbl_to ser_k ser_v buf h =
+      let len = Hashtbl.length h in
+      int_to buf len;
+      Hashtbl.iter
+        (fun k v ->
+         ser_k buf k;
+         ser_v buf v)
+        h
+  end
+
+type 'a deserializer = 'a ReadBuffer.deserializer
+type 'a serializer = 'a WriteBuffer.serializer
+
+module FdReader = struct
+    open Lwt.Infix
+
+    let with_lwt_bytes fd len f =
+      let buf = Lwt_bytes.create len in
+      Lwt.finalize
+        (fun () -> Lwt_extra2.read_all_lwt_bytes_exact fd buf 0 len >>= fun () ->
+                   f buf)
+        (fun () -> Lwt_bytes.unsafe_destroy buf;
+                   Lwt.return_unit)
+
+    let with_buffer_from fd len f =
+      with_lwt_bytes
+        fd len
+        (fun buf ->
+         let b = ReadBuffer.make_buffer buf 0 in
+         f b)
+
+    let from_buf fd len a_from =
+      with_buffer_from
+        fd len
+        (fun buf -> a_from buf |> Lwt.return)
+
+    let int32_from fd =
+      from_buf fd 4 ReadBuffer.int32_from
+
+    let int_from fd =
+      from_buf fd 4 ReadBuffer.int_from
+
+    let raw_string_from fd length =
+      let s = Bytes.create length in
+      Lwt_extra2.read_all_exact fd s 0 length >>= fun () ->
+      Lwt.return s
+
+    let string_from fd =
+      int_from fd >>= fun length ->
+      raw_string_from fd length
+
+    let char_from fd =
+      from_buf fd 1 ReadBuffer.char_from
+
+    let bool_from fd =
+      char_from fd >>= function
+      | '\x00' -> Lwt.return_false
+      | '\x01' -> Lwt.return_true
+      | k -> raise_bad_tag "bool from fd" (Char.code k)
+
+    let option_from a_from fd =
+      bool_from fd >>= function
+      | false -> Lwt.return None
+      | true -> a_from fd >>= fun a -> Lwt.return (Some a)
+  end

--- a/ocaml/src/tools/llio2.ml
+++ b/ocaml/src/tools/llio2.ml
@@ -32,9 +32,9 @@ module ReadBuffer = struct
     let deserialize ?(pos = 0) deserializer buf =
       deserializer { buf; pos; }
 
-    let deserialize' ?(pos = 0) deserializer (buf : Bigstring_slice.t) =
-      deserializer { buf = buf.Bigstring_slice.bs;
-                     pos = pos + buf.Bigstring_slice.offset; }
+    let deserialize' ?(pos = 0) deserializer (buf : Lwt_bytes.t) =
+      deserializer { buf = buf;
+                     pos = pos; }
 
     let unit_from buf = ()
 

--- a/ocaml/src/tools/llio2.ml
+++ b/ocaml/src/tools/llio2.ml
@@ -29,6 +29,13 @@ module ReadBuffer = struct
 
     let buffer_done buf = buf.pos = Lwt_bytes.length buf.buf
 
+    let deserialize ?(pos = 0) deserializer buf =
+      deserializer { buf; pos; }
+
+    let deserialize' ?(pos = 0) deserializer (buf : Bigstring_slice.t) =
+      deserializer { buf = buf.Bigstring_slice.bs;
+                     pos = pos + buf.Bigstring_slice.offset; }
+
     let unit_from buf = ()
 
     let maybe_from_buffer a_from default buf =

--- a/ocaml/src/tools/lwt_extra2.ml
+++ b/ocaml/src/tools/lwt_extra2.ml
@@ -142,8 +142,19 @@ let _read_all read_to_target offset length =
 let read_all_lwt_bytes fd target offset length =
   _read_all (Lwt_bytes.read fd target) offset length
 
+let expect_exact_length len length =
+  if len = length
+  then Lwt.return_unit
+  else Lwt.fail End_of_file
+
+let read_all_lwt_bytes_exact fd target offset length =
+  read_all_lwt_bytes fd target offset length >>= expect_exact_length length
+
 let read_all fd target offset length =
   _read_all (Lwt_unix.read fd target) offset length
+
+let read_all_exact fd target offset length =
+  read_all fd target offset length >>= expect_exact_length length
 
 let _write_all write_from_source offset length =
   let rec inner offset todo =

--- a/ocaml/src/tools/prelude.ml
+++ b/ocaml/src/tools/prelude.ml
@@ -481,6 +481,8 @@ external get32_prim : string -> int -> int32 = "%caml_string_get32"
 external set32_prim' : Lwt_bytes.t -> int -> int32 -> unit = "%caml_bigstring_set32"
 external get32_prim' : Lwt_bytes.t -> int -> int32 = "%caml_bigstring_get32"
 
+external set64_prim' : Lwt_bytes.t -> int -> int64 -> unit = "%caml_bigstring_set64"
+external get64_prim' : Lwt_bytes.t -> int -> int64 = "%caml_bigstring_get64"
 
 let deserialize ?(offset=0) deserializer s =
   deserializer (Llio.make_buffer s offset)

--- a/ocaml/src/tools/slice.ml
+++ b/ocaml/src/tools/slice.ml
@@ -54,11 +54,17 @@ module Slice = struct
     Llio.int_to buffer t.length;
     Buffer.add_substring buffer t.buf t.offset t.length
 
+  let to_buffer' buffer t =
+    Llio2.WriteBuffer.substring_to buffer (t.buf, t.offset, t.length)
+
   let from_buffer buffer =
     let length = Llio.int_from buffer in
     let offset = buffer.Llio.pos in
     buffer.Llio.pos <- offset + length;
     make buffer.Llio.buf offset length
+
+  let from_buffer' buffer =
+    Llio2.ReadBuffer.string_from buffer |> wrap_string
 
   let add_prefix_byte_as_bytes t c =
       let b = Bytes.create (t.length + 1) in

--- a/ocaml/src/tools/stat.ml
+++ b/ocaml/src/tools/stat.ml
@@ -68,29 +68,8 @@ module Stat = struct
       Llio.float_to buf stat.min;
       Llio.float_to buf stat.max;
       Llio.float_to buf stat.alpha
-    let to_buffer' buf stat =
-      let module Llio = Llio2.WriteBuffer in
-      Llio.int64_to buf stat.n;
-      Llio.float_to buf stat.avg;
-      Llio.float_to buf stat.exp_avg;
-      Llio.float_to buf stat.m2;
-      Llio.float_to buf stat.var;
-      Llio.float_to buf stat.min;
-      Llio.float_to buf stat.max;
-      Llio.float_to buf stat.alpha
 
     let stat_from buf =
-      let n       = Llio.int64_from buf in
-      let avg     = Llio.float_from buf in
-      let exp_avg = Llio.float_from buf in
-      let m2      = Llio.float_from buf in
-      let var     = Llio.float_from buf in
-      let min     = Llio.float_from buf in
-      let max     = Llio.float_from buf in
-      let alpha   = Llio.float_from buf in
-      { n;avg;exp_avg;m2;var;min;max; alpha}
-    let from_buffer' buf =
-      let module Llio = Llio2.ReadBuffer in
       let n       = Llio.int64_from buf in
       let avg     = Llio.float_from buf in
       let exp_avg = Llio.float_from buf in

--- a/ocaml/src/tools/stat.ml
+++ b/ocaml/src/tools/stat.ml
@@ -68,8 +68,29 @@ module Stat = struct
       Llio.float_to buf stat.min;
       Llio.float_to buf stat.max;
       Llio.float_to buf stat.alpha
+    let to_buffer' buf stat =
+      let module Llio = Llio2.WriteBuffer in
+      Llio.int64_to buf stat.n;
+      Llio.float_to buf stat.avg;
+      Llio.float_to buf stat.exp_avg;
+      Llio.float_to buf stat.m2;
+      Llio.float_to buf stat.var;
+      Llio.float_to buf stat.min;
+      Llio.float_to buf stat.max;
+      Llio.float_to buf stat.alpha
 
     let stat_from buf =
+      let n       = Llio.int64_from buf in
+      let avg     = Llio.float_from buf in
+      let exp_avg = Llio.float_from buf in
+      let m2      = Llio.float_from buf in
+      let var     = Llio.float_from buf in
+      let min     = Llio.float_from buf in
+      let max     = Llio.float_from buf in
+      let alpha   = Llio.float_from buf in
+      { n;avg;exp_avg;m2;var;min;max; alpha}
+    let from_buffer' buf =
+      let module Llio = Llio2.ReadBuffer in
       let n       = Llio.int64_from buf in
       let avg     = Llio.float_from buf in
       let exp_avg = Llio.float_from buf in

--- a/ocaml/src/tools/stat_deser.ml
+++ b/ocaml/src/tools/stat_deser.ml
@@ -1,0 +1,44 @@
+(*
+Copyright 2015 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+(* These functions live here and not in stat.ml
+ * because otherwise we can't load the plugins
+ * into arakoon
+ *)
+
+open Stat.Stat
+
+let to_buffer' buf stat =
+  let module Llio = Llio2.WriteBuffer in
+  Llio.int64_to buf stat.n;
+  Llio.float_to buf stat.avg;
+  Llio.float_to buf stat.exp_avg;
+  Llio.float_to buf stat.m2;
+  Llio.float_to buf stat.var;
+  Llio.float_to buf stat.min;
+  Llio.float_to buf stat.max;
+  Llio.float_to buf stat.alpha
+let from_buffer' buf =
+  let module Llio = Llio2.ReadBuffer in
+  let n       = Llio.int64_from buf in
+  let avg     = Llio.float_from buf in
+  let exp_avg = Llio.float_from buf in
+  let m2      = Llio.float_from buf in
+  let var     = Llio.float_from buf in
+  let min     = Llio.float_from buf in
+  let max     = Llio.float_from buf in
+  let alpha   = Llio.float_from buf in
+  { n;avg;exp_avg;m2;var;min;max; alpha}

--- a/ocaml/src/tools/statistics_collection.ml
+++ b/ocaml/src/tools/statistics_collection.ml
@@ -76,12 +76,6 @@ module Generic = struct
       Llio.float_to buf t.creation;
       Llio.float_to buf t.period;
       Llio.hashtbl_to Llio.int32_to stat_to buf t.statistics
-    let to_buffer_with_version' ~ser_version buf t=
-      let module Llio = Llio2.WriteBuffer in
-      Llio.int8_to buf ser_version;
-      Llio.float_to buf t.creation;
-      Llio.float_to buf t.period;
-      Llio.hashtbl_to Llio.int32_to to_buffer' buf t.statistics
 
     let to_buffer buf t =
       to_buffer_with_version ~ser_version:1 buf t
@@ -91,15 +85,6 @@ module Generic = struct
       let period   = Llio.float_from buf in
       let statistics =
         let ef buf = Llio.pair_from Llio.int32_from stat_from buf in
-        Llio.hashtbl_from ef buf
-      in
-      { creation; period; statistics}
-    let from_buffer_raw' buf =
-      let module Llio = Llio2.ReadBuffer in
-      let creation = Llio.float_from buf in
-      let period   = Llio.float_from buf in
-      let statistics =
-        let ef buf = Llio.pair_from Llio.int32_from from_buffer' buf in
         Llio.hashtbl_from ef buf
       in
       { creation; period; statistics}

--- a/ocaml/src/tools/statistics_collection.ml
+++ b/ocaml/src/tools/statistics_collection.ml
@@ -76,6 +76,12 @@ module Generic = struct
       Llio.float_to buf t.creation;
       Llio.float_to buf t.period;
       Llio.hashtbl_to Llio.int32_to stat_to buf t.statistics
+    let to_buffer_with_version' ~ser_version buf t=
+      let module Llio = Llio2.WriteBuffer in
+      Llio.int8_to buf ser_version;
+      Llio.float_to buf t.creation;
+      Llio.float_to buf t.period;
+      Llio.hashtbl_to Llio.int32_to to_buffer' buf t.statistics
 
     let to_buffer buf t =
       to_buffer_with_version ~ser_version:1 buf t
@@ -85,6 +91,15 @@ module Generic = struct
       let period   = Llio.float_from buf in
       let statistics =
         let ef buf = Llio.pair_from Llio.int32_from stat_from buf in
+        Llio.hashtbl_from ef buf
+      in
+      { creation; period; statistics}
+    let from_buffer_raw' buf =
+      let module Llio = Llio2.ReadBuffer in
+      let creation = Llio.float_from buf in
+      let period   = Llio.float_from buf in
+      let statistics =
+        let ef buf = Llio.pair_from Llio.int32_from from_buffer' buf in
         Llio.hashtbl_from ef buf
       in
       { creation; period; statistics}

--- a/ocaml/src/tools/statistics_collection_deser.ml
+++ b/ocaml/src/tools/statistics_collection_deser.ml
@@ -1,0 +1,34 @@
+(*
+Copyright 2015 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Statistics_collection.Generic
+
+let to_buffer_with_version' ~ser_version buf t=
+  let module Llio = Llio2.WriteBuffer in
+  Llio.int8_to buf ser_version;
+  Llio.float_to buf t.creation;
+  Llio.float_to buf t.period;
+  Llio.hashtbl_to Llio.int32_to Stat_deser.to_buffer' buf t.statistics
+
+let from_buffer_raw' buf =
+  let module Llio = Llio2.ReadBuffer in
+  let creation = Llio.float_from buf in
+  let period   = Llio.float_from buf in
+  let statistics =
+    let ef buf = Llio.pair_from Llio.int32_from Stat_deser.from_buffer' buf in
+    Llio.hashtbl_from ef buf
+  in
+  { creation; period; statistics}

--- a/ocaml/src/verify.ml
+++ b/ocaml/src/verify.ml
@@ -43,7 +43,7 @@ let verify_and_maybe_repair_object
          let checksum = Layout.index manifest.fragment_checksums chunk_id fragment_id in
          Fragment_helper.verify fragment_data checksum
          >>= fun checksum_valid ->
-         Lwt_bytes.unsafe_destroy fragment_data.Bigstring_slice.bs;
+         Lwt_bytes.unsafe_destroy fragment_data;
          Lwt.return
            (if checksum_valid
             then `Ok

--- a/ocaml/src/verify.ml
+++ b/ocaml/src/verify.ml
@@ -34,22 +34,20 @@ let verify_and_maybe_repair_object
   let verify =
     if verify_checksum
     then
-      fun osd key ~chunk_id ~fragment_id ->
-      osd # multi_get
+      fun (osd : Osd.osd) key ~chunk_id ~fragment_id ->
+      osd # get_option
           Osd.Low
-          [ key ] >>= function
-      | [ None ] -> Lwt.return `Missing
-      | [ Some f ] ->
+          key >>= function
+      | None -> Lwt.return `Missing
+      | Some fragment_data ->
          let checksum = Layout.index manifest.fragment_checksums chunk_id fragment_id in
-         let fragment_data' = Slice.to_bigstring f in
-         Fragment_helper.verify fragment_data' checksum
+         Fragment_helper.verify fragment_data checksum
          >>= fun checksum_valid ->
-         Lwt_bytes.unsafe_destroy fragment_data';
+         Lwt_bytes.unsafe_destroy fragment_data.Bigstring_slice.bs;
          Lwt.return
            (if checksum_valid
             then `Ok
             else `ChecksumMismatch)
-      | _ -> assert false
     else
       fun osd key ~chunk_id ~fragment_id ->
       osd # multi_exists


### PR DESCRIPTION
This replaces #68 .