### PR TITLE
fix for spinning asd (sendfile may return 0 when the target socket is…

### DIFF
--- a/jenkins/run2.sh
+++ b/jenkins/run2.sh
@@ -7,6 +7,7 @@ echo ${WORKSPACE}
 
 eval `${opam_env}`
 
+make clean
 make
 
 find cfg/*.ini -exec sed -i "s,/tmp,${WORKSPACE}/tmp,g" {} \;

--- a/ocaml/src/tools/fsutil.ml
+++ b/ocaml/src/tools/fsutil.ml
@@ -221,6 +221,8 @@ let sendfile_all ~fd_in ~fd_out =
            ~fd_out:fd_out'
            n
        in
-       inner (n - sent)
+       if sent = 0
+       then Lwt.fail End_of_file
+       else inner (n - sent)
   in
   inner

--- a/ocaml/src/tools/fsutil.ml
+++ b/ocaml/src/tools/fsutil.ml
@@ -181,17 +181,6 @@ let disk_usage home =
 let lwt_disk_usage home =
   Lwt_preemptive.detach disk_usage home
 
-let lwt_unix_fd_to_fd
-      (fd : Lwt_unix.file_descr) : int =
-  Obj.magic (Obj.field (Obj.repr fd) 0)
-
-let lwt_unix_fd_to_unix_fd
-      (fd : Lwt_unix.file_descr) : Unix.file_descr =
-  Obj.magic (Obj.field (Obj.repr fd) 0)
-
-let unix_fd_to_fd (fd : Unix.file_descr) : int =
-  Obj.magic fd
-
 let sendfile ~release_runtime_lock =
   let inner =
     (* ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count); *)
@@ -207,8 +196,8 @@ let sendfile ~release_runtime_lock =
 
 let sendfile_all ~fd_in ~fd_out =
   let open Lwt.Infix in
-  let fd_in' = lwt_unix_fd_to_fd fd_in in
-  let fd_out' = lwt_unix_fd_to_fd fd_out in
+  let fd_in' = Lwt_extra2.lwt_unix_fd_to_fd fd_in in
+  let fd_out' = Lwt_extra2.lwt_unix_fd_to_fd fd_out in
   let rec inner = function
     | 0 -> Lwt.return ()
     | n ->

--- a/ocaml/src/tools/lwt_extra2.ml
+++ b/ocaml/src/tools/lwt_extra2.ml
@@ -94,6 +94,16 @@ let rec run_forever msg f delay =
   sleep_approx delay >>= fun () ->
   run_forever msg f delay
 
+let lwt_unix_fd_to_fd
+      (fd : Lwt_unix.file_descr) : int =
+  Obj.magic (Obj.field (Obj.repr fd) 0)
+
+let lwt_unix_fd_to_unix_fd
+      (fd : Lwt_unix.file_descr) : Unix.file_descr =
+  Obj.magic (Obj.field (Obj.repr fd) 0)
+
+let unix_fd_to_fd (fd : Unix.file_descr) : int =
+  Obj.magic fd
 
 let with_fd filename ~flags ~perm f =
   Lwt_unix.openfile filename flags perm >>= fun fd ->

--- a/ocaml/src/tools/networking2.ml
+++ b/ocaml/src/tools/networking2.ml
@@ -38,7 +38,7 @@ let connect_with ip port =
      Lwt_extra2.with_timeout
        ~msg:(Printf.sprintf
                "Timeout on Lwt_unix.connect to fd=%i ip=%s port=%i"
-               (Fsutil.lwt_unix_fd_to_fd fd) ip port)
+               (Lwt_extra2.lwt_unix_fd_to_fd fd) ip port)
        1.
        (fun () ->
         Lwt_unix.connect fd address >>= fun () ->


### PR DESCRIPTION
… in CLOSE_WAIT state, without raising an error)