### PR TITLE
fix test setup

### DIFF
--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -621,10 +621,10 @@ type asd_cfg = {
     __sync_dont_use: bool;
     multicast: float option;
     tls: tls option;
-    __warranty_void__write_blobs : bool option;
+    __warranty_void__write_blobs : bool;
   }[@@deriving yojson]
 
-let make_asd_config ?write_blobs node_id asd_id home port tls=
+let make_asd_config ?(write_blobs = true) node_id asd_id home port tls=
   {node_id;
    asd_id;
    home;


### PR DESCRIPTION
asds refused to start when they have `__warranty_void__write_blobs : null` in their config file