### PR TITLE
Alba accelerated alba

### DIFF
--- a/.projectile
+++ b/.projectile
@@ -1,4 +1,5 @@
 -/ocaml/_build
+-/setup/_build
 -/_virt
 -/cpp/automake_client
 -/cpp/bin

--- a/cfg/fragment_cache_config.json
+++ b/cfg/fragment_cache_config.json
@@ -1,0 +1,22 @@
+// a list of example fragment cache configs (which are under test)
+[
+    [ "none" ], // no fragment cache
+    [ "local", // local (file system based) fragment cache
+      { "path" : "/tmp/x",
+        "max_size" : 100000 // in bytes
+      }],
+    [ "local", { path : "/tmp/x",
+                 max_size : 100000,
+                 rocksdb_max_open_files : 256 // optional, default 256
+               }],
+    [ "alba", // use another (probably ssd based) alba as a cache
+      { albamgr_cfg_url : "/tmp/x",
+        namespaces : [ "a", "b" ]
+      }],
+    [ "alba", { albamgr_cfg_url : "/tmp/x",
+                namespaces : [ "a", "b" ],
+                fragment_cache : // optional, defaults to [ "none" ]
+                [ "local", { path : "/tmp/x",
+                             max_size : 100000 } ]
+              }]
+]

--- a/cfg/fragment_cache_config.json
+++ b/cfg/fragment_cache_config.json
@@ -11,7 +11,10 @@
                }],
     [ "alba", // use another (probably ssd based) alba as a cache
       { albamgr_cfg_url : "/tmp/x",
-        namespaces : [ "a", "b" ],
+        bucket_strategy : [ "1-to-1", {
+            prefix : "myprefix",
+            preset : "mypreset"
+        } ],
         manifest_cache_size : 5000000, // manifest cache size (in bytes)
         albamgr_connection_pool_size  : 10, // optional, default 10
         nsm_host_connection_pool_size : 10, // optional, default 10
@@ -24,7 +27,10 @@
         }
       }],
     [ "alba", { albamgr_cfg_url : "/tmp/x",
-                namespaces : [ "a", "b" ],
+                bucket_strategy : [ "1-to-1", {
+                    prefix : "myprefix",
+                    preset : "mypreset"
+                } ],
                 fragment_cache : // optional, defaults to [ "none" ]
                 [ "local", { path : "/tmp/x",
                              max_size : 100000 } ],

--- a/cfg/fragment_cache_config.json
+++ b/cfg/fragment_cache_config.json
@@ -11,12 +11,23 @@
                }],
     [ "alba", // use another (probably ssd based) alba as a cache
       { albamgr_cfg_url : "/tmp/x",
-        namespaces : [ "a", "b" ]
+        namespaces : [ "a", "b" ],
+        manifest_cache_size : 5000000, // manifest cache size (in bytes)
+        albamgr_connection_pool_size  : 10, // optional, default 10
+        nsm_host_connection_pool_size : 10, // optional, default 10
+        osd_connection_pool_size      : 10, // optional, default 10
+        osd_timeout : 2.0, // optional, default 2.
+        tls_client : { // optional
+            "ca_cert" : "/tmp/cacert.pem",
+            "creds"    : [ "/tmp/my_client/my_client.pem",
+                           "/tmp/my_client/my_client.key" ]
+        }
       }],
     [ "alba", { albamgr_cfg_url : "/tmp/x",
                 namespaces : [ "a", "b" ],
                 fragment_cache : // optional, defaults to [ "none" ]
                 [ "local", { path : "/tmp/x",
-                             max_size : 100000 } ]
+                             max_size : 100000 } ],
+                manifest_cache_size : 5000000
               }]
 ]

--- a/cfg/maintenance_demo.json
+++ b/cfg/maintenance_demo.json
@@ -1,6 +1,8 @@
 {
     "log_level": "debug"
     , "albamgr_cfg_file": "./cfg/test.ini"
+    , "fragment_cache" : ["none"], // optional, defaults to no fragment cache.
+                                   // for other options see fragment_cache_config.json
     , "albamgr_connection_pool_size" : 10  // optional, default 10
     , "nsm_host_connection_pool_size" : 10 // optional, default 10
     , "osd_connection_pool_size" : 10      // optional, default 10

--- a/cfg/proxy_demo.json
+++ b/cfg/proxy_demo.json
@@ -16,8 +16,8 @@
     // tls client config:
     , "tls_client" : {
         "ca_cert" : "/tmp/arakoon/cacert.pem",
-        "cert"    : "/tmp/arakoon/my_client/my_client.pem",
-        "key"     : "/tmp/arakoon/my_client/my_client.key",
+        "creds"    : [ "/tmp/arakoon/my_client/my_client.pem",
+                       "/tmp/arakoon/my_client/my_client.key" ]
     }
     
     // wrap object file usage with posix_fadvise calls

--- a/cfg/proxy_demo.json
+++ b/cfg/proxy_demo.json
@@ -4,8 +4,10 @@
     "port": 10000,
     "albamgr_cfg_file": "./cfg/test.ini",
     "manifest_cache_size" : 100000, // optional, default 100_000
-    "fragment_cache_dir" : "/tmp/proxy_fragment_cache",
-    "fragment_cache_size" : 100000000, // optional, default 100_000_000
+    //"fragment_cache_dir" : "/tmp/proxy_fragment_cache", // obsolete
+    //"fragment_cache_size" : 100000000, // obsolete, default 100_000_000
+    "fragment_cache" : ["none"], // optional, defaults to no fragment cache.
+                                 // for other options see fragment_cache_config.json
     "albamgr_connection_pool_size" : 10, // optional, default 10
     "nsm_host_connection_pool_size" : 10, // optional, default 10
     "osd_connection_pool_size" : 10, // optional, default 10

--- a/ocaml/src/alba_client.ml
+++ b/ocaml/src/alba_client.ml
@@ -388,9 +388,7 @@ class alba_client (base_client : Alba_base_client.client)
 
     method drop_cache_by_id ~global namespace_id =
       Manifest_cache.ManifestCache.drop (base_client # get_manifest_cache) namespace_id;
-      if global
-      then fragment_cache # drop_global namespace_id
-      else fragment_cache # drop_local namespace_id
+      fragment_cache # drop namespace_id ~global
 
     method drop_cache ~global namespace =
       self # nsm_host_access # with_namespace_id

--- a/ocaml/src/alba_client_download.ml
+++ b/ocaml/src/alba_client_download.ml
@@ -172,6 +172,8 @@ let download_fragment
         >>= E.return)
      >>== fun (t_decompress, (maybe_decompressed : Lwt_bytes.t)) ->
 
+     fragment_cache # add namespace_id cache_key maybe_decompressed >>= fun () ->
+
      let t_fragment = Statistics.(FromOsd {
                                      osd_id;
                                      retrieve = t_retrieve;

--- a/ocaml/src/alba_json.ml
+++ b/ocaml/src/alba_json.ml
@@ -193,7 +193,7 @@ module Preset = struct
 
   type osds = Albamgr_protocol.Protocol.Preset.osds =
     | All      [@name "all"]
-    | Explicit of (int32 list [@name "explicit"])
+    | Explicit of int32 list [@name "explicit"]
   [@@deriving yojson]
 
   type checksum_algo =

--- a/ocaml/src/fragment_cache.ml
+++ b/ocaml/src/fragment_cache.ml
@@ -27,7 +27,8 @@ class type cache = object
     method lookup : int32 -> string -> Lwt_bytes.t option Lwt.t
     method lookup2 : int32 -> string -> (int * int * Lwt_bytes.t * int) list -> bool Lwt.t
 
-    method drop : int32 -> unit Lwt.t
+    method drop_local  : int32 -> unit Lwt.t
+    method drop_global : int32 -> unit Lwt.t
     method close : unit -> unit Lwt.t
 end
 
@@ -35,7 +36,8 @@ class no_cache = object(self :# cache)
     method add     bid oid blob   = Lwt.return_unit
     method lookup  bid oid        = Lwt.return_none
     method lookup2 bid oid slices = Lwt.return_false
-    method drop    bid            = Lwt.return_unit
+    method drop_local  bid        = Lwt.return_unit
+    method drop_global bid        = Lwt.return_unit
     method close   ()             = Lwt.return_unit
 end
 
@@ -1030,10 +1032,12 @@ class blob_cache root ~(max_size:int64) ~rocksdb_max_open_files =
       Lwt_log.debug_f "add %lx %S took:%f" bid oid t
 
 
-    method drop bid =
+    method drop_local bid =
       Lwt_log.debug_f ~section "blob_cache # drop %li" bid >>= fun () ->
       Hashtbl.replace _dropping bid ();
       Lwt.return ()
+
+    method drop_global bid = self # drop_local bid
 
     method close () =
       Lwt_log.warning_f ~section "closing database" >>= fun () ->

--- a/ocaml/src/fragment_cache.ml
+++ b/ocaml/src/fragment_cache.ml
@@ -23,26 +23,20 @@ module KV = Rocks_key_value_store
 
 
 class type cache = object
-    method clear_all : unit -> unit Lwt.t
     method add : int32 -> string -> Lwt_bytes.t -> unit Lwt.t
     method lookup : int32 -> string -> Lwt_bytes.t option Lwt.t
     method lookup2 : int32 -> string -> (int * int * Lwt_bytes.t * int) list -> bool Lwt.t
 
     method drop : int32 -> unit Lwt.t
-    method get_count : unit -> int64
-    method get_total_size : unit -> int64
     method close : unit -> unit Lwt.t
 end
 
 class no_cache = object(self :# cache)
-    method clear_all () = Lwt.return_unit
     method add     bid oid blob   = Lwt.return_unit
     method lookup  bid oid        = Lwt.return_none
     method lookup2 bid oid slices = Lwt.return_false
     method drop    bid            = Lwt.return_unit
-    method get_count () = 0L
-    method get_total_size () = 0L
-    method close () = Lwt.return_unit
+    method close   ()             = Lwt.return_unit
 end
 
 let ser64 x=

--- a/ocaml/src/fragment_cache_alba.ml
+++ b/ocaml/src/fragment_cache_alba.ml
@@ -143,9 +143,16 @@ class alba_cache
          Lwt_log.debug_f ~exn "Exception during alba fragment cache lookup2" >>= fun () ->
          Lwt.return_false)
 
-    method drop bid =
-      (* TODO maybe implement something here? *)
+    method drop_local bid =
       Lwt.return_unit
+
+    method drop_global bid =
+      Lwt_extra2.ignore_errors
+        ~logging:true
+        (fun () ->
+         with_namespace
+           bid
+           (fun namespace -> client # delete_namespace ~namespace))
 
     method close () =
       nested_fragment_cache # close () >>= fun () ->

--- a/ocaml/src/fragment_cache_alba.ml
+++ b/ocaml/src/fragment_cache_alba.ml
@@ -143,16 +143,17 @@ class alba_cache
          Lwt_log.debug_f ~exn "Exception during alba fragment cache lookup2" >>= fun () ->
          Lwt.return_false)
 
-    method drop_local bid =
-      Lwt.return_unit
-
-    method drop_global bid =
-      Lwt_extra2.ignore_errors
-        ~logging:true
-        (fun () ->
-         with_namespace
-           bid
-           (fun namespace -> client # delete_namespace ~namespace))
+    method drop bid ~global =
+      if global
+      then
+        Lwt_extra2.ignore_errors
+          ~logging:true
+          (fun () ->
+           with_namespace
+             bid
+             (fun namespace -> client # delete_namespace ~namespace))
+      else
+        Lwt.return_unit
 
     method close () =
       nested_fragment_cache # close () >>= fun () ->

--- a/ocaml/src/fragment_cache_alba.ml
+++ b/ocaml/src/fragment_cache_alba.ml
@@ -1,0 +1,121 @@
+(*
+Copyright 2016 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Prelude
+open Lwt.Infix
+
+class alba_cache
+        ~albamgr_cfg_ref
+        namespace
+        ~nested_fragment_cache
+        ~manifest_cache_size
+        ~albamgr_connection_pool_size
+        ~nsm_host_connection_pool_size
+        ~osd_connection_pool_size
+        ~osd_timeout
+        ~tls_config
+  =
+  let tcp_keepalive = Tcp_keepalive2.default in
+  let albamgr_pool =
+    Remotes.Pool.Albamgr.make
+      ~size:albamgr_connection_pool_size
+      albamgr_cfg_ref
+      tls_config
+      Buffer_pool.default_buffer_pool
+      ~tcp_keepalive
+  in
+  let mgr_access =
+    new Albamgr_client.client (new Albamgr_access.basic_mgr_pooled albamgr_pool)
+  in
+  let base_client = new Alba_base_client.client
+                        nested_fragment_cache
+                        ~mgr_access
+                        ~manifest_cache_size
+                        ~bad_fragment_callback:(fun alba_client
+                                                    ~namespace_id
+                                                    ~object_id ~object_name
+                                                    ~chunk_id ~fragment_id
+                                                    ~location -> ())
+                        ~nsm_host_connection_pool_size
+                        ~osd_connection_pool_size
+                        ~osd_timeout
+                        ~default_osd_priority:Osd.High
+                        ~tls_config
+                        ~tcp_keepalive
+                        ~use_fadvise:true
+  in
+  let client = new Alba_client.alba_client base_client in
+  let make_object_name ~bid ~name =
+    serialize
+      (Llio.pair_to
+         Llio.int32_to
+         Llio.string_to)
+      (bid, name)
+  in
+  object(self :# Fragment_cache.cache)
+    method add bid name blob =
+      Lwt.catch
+        (fun () ->
+         client # upload_object_from_bytes
+                ~namespace
+                ~object_name:(make_object_name ~bid ~name)
+                ~object_data:blob
+                ~checksum_o:None
+                ~allow_overwrite:Nsm_model.Unconditionally >>= fun _ ->
+         Lwt.return_unit)
+        (fun exn ->
+         Lwt_log.debug_f ~exn "Exception while adding object to alba fragment cache")
+
+    method lookup bid name =
+      client # download_object_to_bytes
+             ~object_name:(make_object_name ~bid ~name)
+             ~namespace
+             ~consistent_read:false
+             ~should_cache:true
+
+    method lookup2 bid name object_slices =
+      Lwt.catch
+        (fun () ->
+         client # nsm_host_access # with_namespace_id
+                ~namespace
+                (fun namespace_id ->
+                 base_client # download_object_slices'
+                             ~namespace_id
+                             ~object_name:(make_object_name ~bid ~name)
+                             ~object_slices:(List.map
+                                               (fun (offset, length, dest, dest_off) ->
+                                                Int64.of_int offset, length,
+                                                dest, dest_off)
+                                               object_slices)
+                             ~consistent_read:false
+                             ~fragment_statistics_cb:ignore
+                ) >>= function
+         | None -> Lwt.return_false
+         | Some _ -> Lwt.return_true)
+        (fun exn ->
+         Lwt_log.debug_f ~exn "Exception during alba fragment cache lookup2" >>= fun () ->
+         Lwt.return_false)
+
+    method drop bid =
+      (* TODO maybe implement something here? *)
+      Lwt.return_unit
+
+    method close () =
+      nested_fragment_cache # close () >>= fun () ->
+      base_client # osd_access # finalize;
+      base_client # nsm_host_access # finalize;
+      Lwt_pool2.finalize albamgr_pool
+  end

--- a/ocaml/src/fragment_cache_config.ml
+++ b/ocaml/src/fragment_cache_config.ml
@@ -35,7 +35,7 @@ and local_fragment_cache = {
 
 and alba_fragment_cache = {
     albamgr_cfg_url : string;
-    namespaces : string list;
+    bucket_strategy : Fragment_cache_alba.alba_fragment_cache_bucket_strategy;
     fragment_cache : (fragment_cache [@default None']);
     manifest_cache_size : int;
     albamgr_connection_pool_size  : (int [@default default_connection_pool_size]);
@@ -78,7 +78,7 @@ let rec make_fragment_cache = function
 
      Lwt.return (cache :> Fragment_cache.cache)
   | Alba { albamgr_cfg_url;
-           namespaces;
+           bucket_strategy;
            fragment_cache;
            manifest_cache_size;
            albamgr_connection_pool_size;
@@ -91,8 +91,7 @@ let rec make_fragment_cache = function
      Alba_arakoon.config_from_url (Url.make albamgr_cfg_url) >>= fun albamgr_cfg ->
      let cache = new Fragment_cache_alba.alba_cache
                      ~albamgr_cfg_ref:(ref albamgr_cfg)
-                     (* TODO pass in list of namespaces *)
-                     (List.hd_exn namespaces)
+                     ~bucket_strategy
                      ~nested_fragment_cache
                      ~manifest_cache_size
                      ~albamgr_connection_pool_size

--- a/ocaml/src/fragment_cache_config.ml
+++ b/ocaml/src/fragment_cache_config.ml
@@ -1,0 +1,73 @@
+(*
+Copyright 2016 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Lwt.Infix
+
+let default_rocksdb_max_open_files = 256
+
+type fragment_cache =
+  | None' [@name "none"]
+  | Local of local_fragment_cache [@name "local"]
+  | Alba of alba_fragment_cache [@name "alba"]
+  [@@deriving yojson, show]
+
+and local_fragment_cache = {
+    path : string;
+    max_size : int;
+    rocksdb_max_open_files : (int [@default default_rocksdb_max_open_files]);
+  } [@@deriving yojson, show]
+
+and alba_fragment_cache = {
+    albamgr_cfg_url : string;
+    namespaces : string list;
+    fragment_cache : (fragment_cache [@default None']);
+  } [@@deriving yojson, show]
+
+let rec make_fragment_cache = function
+  | None' ->
+     Lwt.return (new Fragment_cache.no_cache :> Fragment_cache.cache)
+  | Local { path; max_size; rocksdb_max_open_files; } ->
+     assert (path.[0] = '/');
+     let max_size = Int64.of_int max_size in
+     let max_size =
+       (* the fragment cache size is currently a rather soft limit which we'll
+        * surely exceed. this can lead to disk full conditions. by taking a
+        * safety margin of 15% we turn the soft limit into a hard one... *)
+       let open Int64 in
+       mul (div max_size 100L) 85L
+     in
+     Fragment_cache.safe_create path ~max_size ~rocksdb_max_open_files
+     >>= fun cache ->
+
+     let rec fragment_cache_disk_usage_t () =
+       Lwt.catch
+         (fun () ->
+          Fsutil.lwt_disk_usage path >>= fun (used_b, total_b) ->
+          let percentage =
+            100.0 *. ((Int64.to_float used_b) /. (Int64.to_float total_b))
+          in
+          Lwt_log.info_f "fragment_cache disk_usage: %.2f%%" percentage)
+         (fun exn -> Lwt_log.warning ~exn "fragment_cache_disk_usage_t")
+       >>= fun () ->
+       Lwt_unix.sleep 60.0 >>= fun () ->
+       fragment_cache_disk_usage_t ()
+     in
+     Lwt.ignore_result (fragment_cache_disk_usage_t ());
+
+     Lwt.return (cache :> Fragment_cache.cache)
+  | Alba { albamgr_cfg_url; namespaces; fragment_cache; } ->
+     let nested_cache = make_fragment_cache fragment_cache in
+     failwith "TODO"

--- a/ocaml/src/fragment_cache_config_test.ml
+++ b/ocaml/src/fragment_cache_config_test.ml
@@ -34,7 +34,8 @@ let test_example_config () =
         };
       Alba {
           albamgr_cfg_url = "/tmp/x";
-          namespaces = [ "a"; "b"; ];
+          bucket_strategy = Fragment_cache_alba.(OneOnOne { preset = "mypreset";
+                                                            prefix = "myprefix"; });
           fragment_cache = None';
           manifest_cache_size = 5_000_000;
           albamgr_connection_pool_size  = default_connection_pool_size;
@@ -47,7 +48,8 @@ let test_example_config () =
         };
       Alba {
           albamgr_cfg_url = "/tmp/x";
-          namespaces = [ "a"; "b"; ];
+          bucket_strategy = Fragment_cache_alba.(OneOnOne { preset = "mypreset";
+                                                            prefix = "myprefix"; });
           fragment_cache = Local {
                                path = "/tmp/x";
                                max_size = 100_000;

--- a/ocaml/src/fragment_cache_config_test.ml
+++ b/ocaml/src/fragment_cache_config_test.ml
@@ -36,6 +36,14 @@ let test_example_config () =
           albamgr_cfg_url = "/tmp/x";
           namespaces = [ "a"; "b"; ];
           fragment_cache = None';
+          manifest_cache_size = 5_000_000;
+          albamgr_connection_pool_size  = default_connection_pool_size;
+          nsm_host_connection_pool_size = default_connection_pool_size;
+          osd_connection_pool_size      = default_connection_pool_size;
+          osd_timeout = default_osd_timeout;
+          tls_client = Some Tls.({ ca_cert = "/tmp/cacert.pem";
+                                   creds = Some ("/tmp/my_client/my_client.pem",
+                                                 "/tmp/my_client/my_client.key") });
         };
       Alba {
           albamgr_cfg_url = "/tmp/x";
@@ -45,6 +53,12 @@ let test_example_config () =
                                max_size = 100_000;
                                rocksdb_max_open_files = default_rocksdb_max_open_files;
                              };
+          manifest_cache_size = 5_000_000;
+          albamgr_connection_pool_size  = default_connection_pool_size;
+          nsm_host_connection_pool_size = default_connection_pool_size;
+          osd_connection_pool_size      = default_connection_pool_size;
+          osd_timeout = default_osd_timeout;
+          tls_client = None;
         };
     ]
   in

--- a/ocaml/src/fragment_cache_config_test.ml
+++ b/ocaml/src/fragment_cache_config_test.ml
@@ -1,0 +1,71 @@
+(*
+Copyright 2016 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Lwt.Infix
+open Fragment_cache_config
+
+type t_list = fragment_cache list [@@deriving yojson, show]
+
+let test_example_config () =
+  let caches = [
+      None';
+      Local {
+          path = "/tmp/x";
+          max_size = 100000;
+          rocksdb_max_open_files = default_rocksdb_max_open_files;
+        };
+      Local {
+          path = "/tmp/x";
+          max_size = 100000;
+          rocksdb_max_open_files = 256;
+        };
+      Alba {
+          albamgr_cfg_url = "/tmp/x";
+          namespaces = [ "a"; "b"; ];
+          fragment_cache = None';
+        };
+      Alba {
+          albamgr_cfg_url = "/tmp/x";
+          namespaces = [ "a"; "b"; ];
+          fragment_cache = Local {
+                               path = "/tmp/x";
+                               max_size = 100_000;
+                               rocksdb_max_open_files = default_rocksdb_max_open_files;
+                             };
+        };
+    ]
+  in
+  let file = "./cfg/fragment_cache_config.json" in
+  let t () =
+    Lwt_extra2.read_file file >>= fun txt ->
+    let json = Yojson.Safe.from_string txt in
+    let caches' = match t_list_of_yojson json with
+      | `Error e -> failwith e
+      | `Ok r -> r
+    in
+    Lwt_log.debug_f "Expected %s, got %s"
+                    (show_t_list caches)
+                    (show_t_list caches') >>= fun () ->
+    assert (caches = caches');
+    Lwt.return ()
+  in
+  Lwt_main.run (t ())
+
+open OUnit
+
+let suite = "fragment_cache_config_test" >:::[
+      "test_example_config" >:: test_example_config;
+    ]

--- a/ocaml/src/fragment_cache_test.ml
+++ b/ocaml/src/fragment_cache_test.ml
@@ -186,7 +186,7 @@ let test_5 () =
     let printer = Int64.to_string in
     OUnit.assert_equal
       ~printer ~msg:"cache count" 8L (cache # get_count ());
-    cache # drop_global 0l >>= fun () ->
+    cache # drop ~global:true 0l >>= fun () ->
 
     (* evict the first 4 victims (should all come from bid 0) *)
     let rec inner = function
@@ -216,13 +216,13 @@ let test_long () =
     let bid_to_drop1 = Int32.of_int 21 in
     let blob = Lwt_bytes.of_string "blob" in
     cache # add bid_to_drop1 "oid" blob >>= fun () ->
-    cache # drop_global bid_to_drop1 >>= fun () ->
+    cache # drop ~global:true bid_to_drop1 >>= fun () ->
     let bid_to_drop2 = Int32.of_int 20 in
     cache # add bid_to_drop2 "oid1" blob >>= fun () ->
     cache # add bid_to_drop2 "oid2" blob >>= fun () ->
-    cache # drop_global bid_to_drop2 >>= fun () ->
-    cache # drop_global 22l >>= fun () ->
-    cache # drop_global 23l >>= fun () ->
+    cache # drop ~global:true bid_to_drop2 >>= fun () ->
+    cache # drop ~global:true 22l >>= fun () ->
+    cache # drop ~global:true 23l >>= fun () ->
     let make_blob () = Lwt_bytes.create (2048 + Random.int 2048) in
     let fill n =
       let rec loop i =
@@ -267,7 +267,7 @@ let test_long () =
     Lwt_log.debug_f "fill loop took: %3f" d >>= fun () ->
     fetch 1000 >>= fun (found, missed) ->
     Lwt_io.printlf "done: found:%i missed:%i" found missed >>= fun () ->
-    cache # drop_global 0l >>= fun () ->
+    cache # drop ~global:true 0l >>= fun () ->
     assert (cache # _check ());
     Lwt.return ()
   in

--- a/ocaml/src/fragment_cache_test.ml
+++ b/ocaml/src/fragment_cache_test.ml
@@ -186,7 +186,7 @@ let test_5 () =
     let printer = Int64.to_string in
     OUnit.assert_equal
       ~printer ~msg:"cache count" 8L (cache # get_count ());
-    cache # drop 0l >>= fun () ->
+    cache # drop_global 0l >>= fun () ->
 
     (* evict the first 4 victims (should all come from bid 0) *)
     let rec inner = function
@@ -216,13 +216,13 @@ let test_long () =
     let bid_to_drop1 = Int32.of_int 21 in
     let blob = Lwt_bytes.of_string "blob" in
     cache # add bid_to_drop1 "oid" blob >>= fun () ->
-    cache # drop bid_to_drop1 >>= fun () ->
+    cache # drop_global bid_to_drop1 >>= fun () ->
     let bid_to_drop2 = Int32.of_int 20 in
     cache # add bid_to_drop2 "oid1" blob >>= fun () ->
     cache # add bid_to_drop2 "oid2" blob >>= fun () ->
-    cache # drop bid_to_drop2 >>= fun () ->
-    cache # drop 22l >>= fun () ->
-    cache # drop 23l >>= fun () ->
+    cache # drop_global bid_to_drop2 >>= fun () ->
+    cache # drop_global 22l >>= fun () ->
+    cache # drop_global 23l >>= fun () ->
     let make_blob () = Lwt_bytes.create (2048 + Random.int 2048) in
     let fill n =
       let rec loop i =
@@ -267,7 +267,7 @@ let test_long () =
     Lwt_log.debug_f "fill loop took: %3f" d >>= fun () ->
     fetch 1000 >>= fun (found, missed) ->
     Lwt_io.printlf "done: found:%i missed:%i" found missed >>= fun () ->
-    cache # drop 0l >>= fun () ->
+    cache # drop_global 0l >>= fun () ->
     assert (cache # _check ());
     Lwt.return ()
   in

--- a/ocaml/src/proxy_server.ml
+++ b/ocaml/src/proxy_server.ml
@@ -323,7 +323,7 @@ let proxy_protocol (alba_client : Alba_client.alba_client)
     | InvalidateCache ->
       fun stats namespace -> alba_client # invalidate_cache namespace
     | DropCache ->
-      fun stats namespace -> alba_client # drop_cache namespace
+      fun stats namespace -> alba_client # drop_cache namespace ~global:false
     | ProxyStatistics ->
        fun stats clear ->
        begin

--- a/ocaml/src/proxy_server.ml
+++ b/ocaml/src/proxy_server.ml
@@ -568,9 +568,9 @@ let refresh_albamgr_cfg
   inner ()
 
 let run_server hosts port
-               cache_dir albamgr_client_cfg
+               albamgr_client_cfg
+               ~fragment_cache
                ~manifest_cache_size
-               ~fragment_cache_size
                ~albamgr_connection_pool_size
                ~nsm_host_connection_pool_size
                ~osd_connection_pool_size
@@ -584,21 +584,6 @@ let run_server hosts port
   Lwt_log.info_f "proxy_server version:%s" Alba_version.git_revision
   >>= fun () ->
   let stats = ProxyStatistics.make () in
-
-  let rec fragment_cache_disk_usage_t () =
-    Lwt.catch
-      (fun () ->
-       Fsutil.lwt_disk_usage cache_dir >>= fun (used_b, total_b) ->
-       let percentage =
-         100.0 *. ((Int64.to_float used_b) /. (Int64.to_float total_b))
-       in
-       Lwt_log.info_f "fragment_cache disk_usage: %.2f%%" percentage)
-      (fun exn -> Lwt_log.warning ~exn "fragment_cache_disk_usage_t")
-    >>= fun () ->
-    Lwt_unix.sleep 60.0 >>= fun () ->
-    fragment_cache_disk_usage_t ()
-  in
-
 
   Lwt.catch
     (fun () ->
@@ -618,8 +603,7 @@ let run_server hosts port
                    ~version_id:(snd location))) in
        Alba_client.with_client
          albamgr_client_cfg
-         ~cache_dir
-         ~fragment_cache_size
+         ~fragment_cache
          ~manifest_cache_size
          ~bad_fragment_callback
          ~albamgr_connection_pool_size
@@ -649,7 +633,6 @@ let run_server hosts port
                   proxy_protocol alba_client albamgr_client_cfg stats nfd));
               (Lwt_extra2.make_fuse_thread ());
               Mem_stats.reporting_t ~section:Lwt_log.Section.main ();
-              (fragment_cache_disk_usage_t ());
               (let rec log_stats () =
                  Lwt_log.info_f
                    "stats:\n%s%!"

--- a/ocaml/src/test.ml
+++ b/ocaml/src/test.ml
@@ -37,4 +37,5 @@ let suite = "all" >:::[
     Buffer_pool_test.suite;
     Maintenance_coordination_test.suite;
     Posix_test.suite;
+    Fragment_cache_config_test.suite;
   ]

--- a/setup/prul.ml
+++ b/setup/prul.ml
@@ -80,6 +80,8 @@ module Shell = struct
     String.concat " " x |> cmd
 
   let cp src tgt = Printf.sprintf "cp %s %s" src tgt |> cmd
+
+  let mkdir p = "mkdir -p " ^ p |> cmd
 end
 
 module Etcdctl = struct


### PR DESCRIPTION
This pull request allows using e.g. a flash based alba as a fragment cache for a hard disk based alba.

Some more (related) changes are still to come in further pull requests:
- cache eviction
- extra statistics for the proxy
- configure cache on read/write behavior
- partial reads on the asds when no fragment cache is configured
- attempt to remove items from the fragment cache when removing/overwriting an object