### PR TITLE
Asd performance (benchmarking)

### DIFF
--- a/ocaml/src/alba.ml
+++ b/ocaml/src/alba.ml
@@ -50,7 +50,7 @@ let alba_get_id cfg_file tls_config to_json verbose attempts =
          end else
            Lwt_io.printlf "The id for this alba instance is %s" alba_id)
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_get_id_cmd =
   Term.(pure alba_get_id
@@ -79,7 +79,7 @@ let osd_multi_get osd_id cfg_file tls_config keys unescape verbose =
                              values_s in
               Lwt_io.printlf "%s" ([%show : string option list] values)))
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let osd_multi_get_cmd =
   let keys = Arg.(non_empty &
@@ -110,7 +110,7 @@ let osd_range osd_id cfg_file tls_config verbose =
               Lwt_io.printlf "%s"
                 ([%show : string list] keys)))
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let osd_range_cmd =
   Term.(pure osd_range
@@ -130,7 +130,7 @@ let alba_claim_osd alba_cfg_file tls_config long_id to_json verbose =
          alba_client # claim_osd ~long_id) >>= fun osd_id ->
     Lwt_log.debug_f "Claimed %S with id=%li" long_id osd_id
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_claim_osd_cmd =
   Term.(pure alba_claim_osd
@@ -150,7 +150,7 @@ let alba_decommission_osd alba_cfg_file tls_config long_id to_json verbose =
       alba_cfg_file tls_config
       (fun alba_client -> alba_client # decommission_osd ~long_id)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_decommission_osd_cmd =
   Term.(pure alba_decommission_osd
@@ -172,7 +172,7 @@ let alba_purge_osd alba_cfg_file tls_config long_id to_json verbose =
       alba_cfg_file tls_config
       (fun alba_client -> alba_client # mgr_access # purge_osd ~long_id)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_purge_osd_cmd =
   Term.(pure alba_purge_osd
@@ -203,7 +203,7 @@ let alba_list_ns_osds cfg_file tls_config namespace verbose =
          >>= fun () ->
          Lwt.return ())
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 
 let alba_list_ns_osds_cmd =
@@ -271,7 +271,7 @@ let alba_show_namespace cfg_file tls_config namespace to_json verbose =
                     end
                ))
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_show_namespace_cmd =
   Term.(pure alba_show_namespace
@@ -368,7 +368,7 @@ let alba_show_namespaces cfg_file tls_config first finc last max reverse to_json
          end
       )
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_show_namespaces_cmd =
   Term.(pure alba_show_namespaces
@@ -404,7 +404,7 @@ let alba_upload_object
                         input_file
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_upload_object_cmd =
   Term.(pure alba_upload_object
@@ -443,7 +443,7 @@ let alba_download_object
       Lwt_io.printlf "object %s with size %Li downloaded to file %s"
                      object_name manifest.Nsm_model.Manifest.size output_file
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_download_object_cmd =
   Term.(pure alba_download_object
@@ -466,7 +466,7 @@ let alba_delete_object cfg_file tls_config namespace object_name verbose =
                      ~object_name
                      ~may_not_exist:false)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_show_object
       cfg_file tls_config
@@ -502,7 +502,7 @@ let alba_show_object
             end
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_show_object_cmd =
   Term.(pure alba_show_object
@@ -545,7 +545,7 @@ let alba_list_objects cfg_file tls_config namespace verbose =
       cnt
       ([%show: string list] objs)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_list_objects_cmd =
   Term.(pure alba_list_objects
@@ -567,7 +567,7 @@ let alba_get_nsm_version cfg_file tls_config nsm_host_id verbose =
          major minor patch hash
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_get_nsm_version_cmd =
   Term.(pure alba_get_nsm_version
@@ -589,7 +589,7 @@ let alba_create_namespace cfg_file tls_config namespace preset_name verbose =
          Lwt_io.printlf "Create namespace successful, got id %li" namespace_id
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_create_namespace_cmd =
   Term.(pure alba_create_namespace
@@ -610,7 +610,7 @@ let alba_delete_namespace cfg_file tls_config namespace verbose =
          Lwt_io.printlf "Delete namespace successful"
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_delete_namespace_cmd =
   Term.(pure alba_delete_namespace
@@ -713,7 +713,7 @@ let alba_get_disk_safety
            end
       )
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_get_disk_safety_cmd =
   let long_ids =
@@ -763,7 +763,7 @@ let namespace_recovery_agent
            workers worker_id
            osds)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let namespace_recovery_agent_cmd =
   Term.(pure namespace_recovery_agent
@@ -959,6 +959,7 @@ let () =
         Cli_messages.cmds;
         Cli_nsm_host.cmds;
         Cli_bench.cmds;
+        Asd_bench.cmds;
         cmds1; ]
   in
   match Term.eval_choice default_cmd cmds with

--- a/ocaml/src/alba_bench.ml
+++ b/ocaml/src/alba_bench.ml
@@ -60,6 +60,7 @@ object
     method delete_object ~namespace ~object_name ~may_not_exist=
       alba_client # delete_object ~namespace ~object_name ~may_not_exist
 
+    method get_version = Lwt.return Alba_version.summary
 end
 
 let do_scenarios

--- a/ocaml/src/asd_bench.ml
+++ b/ocaml/src/asd_bench.ml
@@ -1,0 +1,108 @@
+(*
+Copyright 2016 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Lwt_bytes2
+open Lwt.Infix
+open Cmdliner
+open Cli_common
+open Cli_bench_common
+
+
+(* TODO bench_asd_no_network *)
+(* TODO bench 1 big file *)
+
+
+let bench_blobs path scenarios count value_size partial_read_size =
+  let t () =
+    let module D = Asd_server.DirectoryInfo in
+    let module B = Generic_bench in
+    let dir_info =
+      D.make
+        ~use_fadvise:true
+        ~use_fallocate:true
+        path
+    in
+    let write_scenario progress =
+      let blob = Lwt_bytes.create_random value_size in
+      let blob = Asd_protocol.Blob.Lwt_bytes blob in
+      let write fnr =
+        D.write_blob
+          dir_info
+          (Int64.of_int fnr) blob
+          ~post_write:(fun fd len parent_dir -> Lwt.return ())
+          ~sync_parent_dirs:true
+      in
+      B.measured_loop
+        progress
+        write
+        count
+    in
+    let partial_read_scenario progress =
+      let target = Lwt_bytes.create partial_read_size in
+      B.measured_loop
+        progress
+        (fun fnr ->
+         D.with_blob_fd
+           dir_info
+           (Int64.of_int fnr)
+           (fun fd ->
+            Lwt_unix.lseek fd 0 Lwt_unix.SEEK_SET >>= fun _ ->
+            Lwt_extra2.read_all_lwt_bytes_exact fd target 0 partial_read_size))
+        count
+    in
+    Lwt_list.iter_s
+      (fun scenario ->
+       let progress = B.make_progress (count/100) in
+       (match snd scenario with
+        | `Writes -> write_scenario
+        | `PartialReads -> partial_read_scenario)
+         progress >>= fun r ->
+       B.report (fst scenario) r)
+      scenarios
+  in
+  lwt_cmd_line ~to_json:false ~verbose:false t
+
+let bench_blobs_cmd =
+  Term.(pure bench_blobs
+        $ Arg.(required
+               & pos 0 (some file) None
+               & info [] ~docv:"PATH")
+        $ Arg.(
+          let scns = [ "writes", `Writes;
+                       "partial_reads", `PartialReads;
+                     ] in
+          let scns' = List.map
+                        (fun (name, v) ->
+                         name, (name, v))
+                        scns
+          in
+          value
+          & opt_all (enum scns') scns
+          & info [ "scenario" ]
+                 ~doc:(Printf.sprintf
+                         "choose which scenario to run, valid values are %s"
+                         ([%show : string list] (List.map fst scns)))
+          )
+        $ n 10000
+        $ value_size 1_000_000
+        $ partial_fetch_size 4096
+  ),
+  Term.info "asd-bench-blobs"
+
+
+let cmds = [
+    bench_blobs_cmd;
+  ]

--- a/ocaml/src/asd_bench.ml
+++ b/ocaml/src/asd_bench.ml
@@ -59,6 +59,8 @@ let bench_blobs path scenarios count value_size partial_read_size =
            dir_info
            (Int64.of_int fnr)
            (fun fd ->
+            let ufd = Lwt_unix.unix_file_descr fd in
+            Posix.posix_fadvise ufd 0 value_size Posix.POSIX_FADV_RANDOM;
             Lwt_unix.lseek fd 0 Lwt_unix.SEEK_SET >>= fun _ ->
             Lwt_extra2.read_all_lwt_bytes_exact fd target 0 partial_read_size))
         count

--- a/ocaml/src/asd_server.ml
+++ b/ocaml/src/asd_server.ml
@@ -367,6 +367,9 @@ module Net_fd = struct
     match fd_out with
     | Plain fd ->
        Fsutil.sendfile_all
+         ~wait_readable:false
+         ~wait_writeable:true
+         ~detached:true
          ~fd_in
          ~fd_out:fd
          size

--- a/ocaml/src/cli_asd.ml
+++ b/ocaml/src/cli_asd.ml
@@ -307,6 +307,7 @@ let osd_bench_cmd =
                       "upload_fragments", upload_fragments;
                       "ranges",range_queries;
                       "partial_reads", partial_reads;
+                      "get_version", get_version;
                     ]
          in
          value

--- a/ocaml/src/cli_asd.ml
+++ b/ocaml/src/cli_asd.ml
@@ -308,6 +308,7 @@ let osd_bench_cmd =
                       "ranges",range_queries;
                       "partial_reads", partial_reads;
                       "get_version", get_version;
+                      "exists", exists;
                     ]
          in
          value

--- a/ocaml/src/cli_asd.ml
+++ b/ocaml/src/cli_asd.ml
@@ -17,6 +17,7 @@ limitations under the License.
 open Cmdliner
 open Lwt.Infix
 open Cli_common
+open Cli_bench_common
 open Checksum
 open Slice
 open Asd_protocol
@@ -115,7 +116,7 @@ let buffer_pool = Buffer_pool.osd_buffer_pool
 
 let run_with_asd_client' ~conn_info asd_id verbose f =
   lwt_cmd_line
-    false verbose
+    ~to_json:false ~verbose
     (fun () ->
      Asd_client.with_client
        buffer_pool
@@ -134,7 +135,7 @@ let with_osd_client (conn_info:Networking2.conn_info) osd_id f =
 
 let run_with_osd_client' conn_info osd_id verbose f =
   lwt_cmd_line
-    false verbose
+    ~to_json:false ~verbose
     (fun () -> with_osd_client conn_info osd_id f)
 
 let asd_set hosts port tls_config asd_id (verbose:bool) key value =
@@ -285,7 +286,7 @@ let osd_bench hosts port tls_config osd_id
   =
   let conn_info = Networking2.make_conn_info hosts port tls_config in
   lwt_cmd_line
-    false verbose
+    ~to_json:false ~verbose
     (fun () ->
      Osd_bench.do_scenarios
        (fun f ->
@@ -298,48 +299,6 @@ let osd_bench hosts port tls_config osd_id
        scenarios)
 
 let osd_bench_cmd =
-  let n_clients default =
-    let doc = "number of concurrent clients for the benchmark" in
-    Arg.(value
-         & opt int default
-         & info ["n-clients"] ~docv:"N_CLIENTS" ~doc)
-  in
-  let n default =
-    let doc = "do runs (gets,sets,...) of $(docv) iterations" in
-    Arg.(value
-         & opt int default
-         & info ["n"; "nn"] ~docv:"N" ~doc)
-  in
-  let value_size default =
-    let doc = "do sets of $(docv) bytes" in
-    Arg.(
-      value
-        & opt int default
-        & info ["v"; "value-size"] ~docv:"V" ~doc
-    )
-  in
-  let partial_fetch_size default =
-    let doc = "do partial reads of $(docv) bytes" in
-    Arg.(
-      value
-      & opt int default
-      & info ["v-partial";] ~doc
-    )
-  in
-  let power default =
-    let doc = "$(docv) for random number generation: period = 10^$(docv)" in
-    Arg.(value
-           & opt int default
-           & info ["power"] ~docv:"power" ~doc
-    )
-  in
-  let prefix default =
-    let doc = "$(docv) to keep multiple clients out of each other's way" in
-    Arg.(value
-           & opt string default
-           & info ["prefix"] ~docv:"prefix" ~doc
-    )
-  in
   let scenarios =
     Arg.(let open Osd_bench in
          let scns = [ "sets", sets;
@@ -473,7 +432,7 @@ let asd_multistatistics long_ids to_json verbose cfg_file tls_config clear =
       >>= fun results ->
       process_results results
     in
-    lwt_cmd_line to_json verbose t
+    lwt_cmd_line ~to_json ~verbose t
   end
 
 let asd_multistatistics_cmd =
@@ -542,7 +501,7 @@ let asd_statistics hosts port_o asd_id to_json verbose config_o tls_config clear
               end
            )
        in
-       lwt_cmd_line to_json verbose t
+       lwt_cmd_line ~to_json ~verbose t
      end
   | Some port,_ -> from_asd hosts port tls_config asd_id verbose
 
@@ -590,7 +549,7 @@ let asd_discover verbose () =
          ([%show: int option] record.port)
          ([%show: int option] record.tlsPort)
   in
-  lwt_cmd_line false verbose (fun () -> discovery seen)
+  lwt_cmd_line ~to_json:false ~verbose (fun () -> discovery seen)
 
 let asd_discover_cmd =
   let term = Term.(pure asd_discover $ verbose $ pure ()) in

--- a/ocaml/src/cli_bench.ml
+++ b/ocaml/src/cli_bench.ml
@@ -31,7 +31,9 @@ let scenarios =
   let scns = [ "writes", `Writes;
                "reads", `Reads;
                "partial-reads", `Partial_reads;
-               "deletes", `Deletes; ] in
+               "deletes", `Deletes;
+               "get_version", `GetVersion;
+             ] in
   Arg.(value
        & opt_all
            (enum scns)
@@ -53,12 +55,15 @@ let map_scenarios scenarios robust =
       | `Writes -> do_writes ~robust
       | `Reads  -> do_reads
       | `Partial_reads -> do_partial_reads
-      | `Deletes -> do_deletes)
+      | `Deletes -> do_deletes
+      | `GetVersion -> do_get_version)
     (if scenarios = []
      then [ `Writes;
             `Reads;
             `Partial_reads;
-            `Deletes; ]
+            `Deletes;
+            `GetVersion;
+          ]
      else scenarios)
 
 let proxy_bench host port

--- a/ocaml/src/cli_bench.ml
+++ b/ocaml/src/cli_bench.ml
@@ -16,33 +16,9 @@ limitations under the License.
 
 open Cmdliner
 open Cli_common
+open Cli_bench_common
 open Prelude
 
-let n_clients default =
-  let doc = "number of concurrent clients for the benchmark" in
-  Arg.(value
-       & opt int default
-       & info ["n-clients"] ~docv:"N_CLIENTS" ~doc)
-
-let n default =
-  let doc = "do runs (writes,reads,partial_reads,...) of $(docv) iterations" in
-  Arg.(value
-       & opt int default
-       & info ["n"; "nn"] ~docv:"N" ~doc)
-
-let power default =
-  let doc = "$(docv) for random number generation: period = 10^$(docv)" in
-  Arg.(value
-       & opt int default
-       & info ["power"] ~docv:"power" ~doc
-  )
-
-let prefix default =
-  let doc = "$(docv) to keep multiple clients out of each other's way" in
-  Arg.(value
-       & opt string default
-       & info ["prefix"] ~docv:"prefix" ~doc
-  )
 
 let slice_size default =
   let doc = "partial reads phaze will use slices of size $(docv)" in
@@ -91,7 +67,7 @@ let proxy_bench host port
                 scenarios robust
   =
   lwt_cmd_line
-    false false
+    ~to_json:false ~verbose:false
     (fun () ->
      Proxy_bench.do_scenarios
        host port
@@ -125,7 +101,7 @@ let alba_bench alba_cfg_url tls_config
                scenarios robust
   =
   lwt_cmd_line
-    false false
+    ~to_json:false ~verbose:false
     (fun () ->
      let open Lwt.Infix in
      Alba_arakoon.config_from_url alba_cfg_url >>= fun cfg ->

--- a/ocaml/src/cli_bench_common.ml
+++ b/ocaml/src/cli_bench_common.ml
@@ -1,0 +1,60 @@
+(*
+Copyright 2016 iNuron NV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*)
+
+open Cmdliner
+
+
+let n_clients default =
+  let doc = "number of concurrent clients for the benchmark" in
+  Arg.(value
+       & opt int default
+       & info ["n-clients"] ~docv:"N_CLIENTS" ~doc)
+
+let n default =
+  let doc = "do runs (writes,reads,partial_reads,...) of $(docv) iterations" in
+  Arg.(value
+       & opt int default
+       & info ["n"; "nn"] ~docv:"N" ~doc)
+
+let power default =
+  let doc = "$(docv) for random number generation: period = 10^$(docv)" in
+  Arg.(value
+       & opt int default
+       & info ["power"] ~docv:"power" ~doc
+  )
+
+let prefix default =
+  let doc = "$(docv) to keep multiple clients out of each other's way" in
+  Arg.(value
+       & opt string default
+       & info ["prefix"] ~docv:"prefix" ~doc
+  )
+
+let value_size default =
+  let doc = "do sets of $(docv) bytes" in
+  Arg.(
+    value
+    & opt int default
+    & info ["v"; "value-size"] ~docv:"V" ~doc
+  )
+
+let partial_fetch_size default =
+  let doc = "do partial reads of $(docv) bytes" in
+  Arg.(
+    value
+    & opt int default
+    & info ["v-partial";] ~doc
+  )

--- a/ocaml/src/cli_common.ml
+++ b/ocaml/src/cli_common.ml
@@ -129,7 +129,7 @@ let exn_to_string_code = function
     "unknown", 0,
     Printexc.to_string exn
 
-let lwt_cmd_line to_json verbose t =
+let lwt_cmd_line ~to_json ~verbose t =
   let t' () =
     Lwt.catch
       (fun () ->
@@ -159,18 +159,18 @@ let lwt_cmd_line to_json verbose t =
   in
   Lwt_main.run (t' ())
 
-let lwt_cmd_line_result to_json verbose t res_to_json =
+let lwt_cmd_line_result ~to_json ~verbose t res_to_json =
   lwt_cmd_line
-    to_json verbose
+    ~to_json ~verbose
     (fun () ->
        t () >>= fun res ->
        if to_json
        then print_result res res_to_json
        else Lwt.return ())
 
-let lwt_cmd_line_unit to_json verbose t =
+let lwt_cmd_line_unit ~to_json ~verbose t =
   lwt_cmd_line_result
-    to_json verbose
+    ~to_json ~verbose
     t
     (fun () -> `Assoc [])
 

--- a/ocaml/src/cli_maintenance.ml
+++ b/ocaml/src/cli_maintenance.ml
@@ -296,7 +296,7 @@ let alba_deliver_messages cfg_file tls_config =
            nsms
       )
   in
-  lwt_cmd_line false true t
+  lwt_cmd_line ~to_json:false ~verbose:true t
 
 let alba_deliver_messages_cmd =
   Term.(pure alba_deliver_messages
@@ -327,7 +327,7 @@ let alba_rewrite_object
                   ~namespace_id
                   ~manifest))
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_rewrite_object_cmd =
   Term.(pure alba_rewrite_object

--- a/ocaml/src/cli_messages.ml
+++ b/ocaml/src/cli_messages.ml
@@ -81,7 +81,7 @@ let list_nsm_host_messages cfg_url tls_config attempts (destinations: string lis
          ) xs
       )
   in
-  lwt_cmd_line false false t
+  lwt_cmd_line ~to_json:false ~verbose:false t
 
 let list_nsm_host_messages_cmd =
   let nsm_hosts =
@@ -119,7 +119,7 @@ let list_osd_messages cfg_file tls_config attempts (destinations:int32 list) ver
          ) xs
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let list_osd_messages_cmd =
   let destinations  =

--- a/ocaml/src/cli_mgr.ml
+++ b/ocaml/src/cli_mgr.ml
@@ -40,7 +40,7 @@ let alba_list_namespaces cfg_file tls_config to_json verbose =
                 namespaces)
       )
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 
 let alba_list_namespaces_cmd =
@@ -87,7 +87,7 @@ let alba_list_namespaces_by_id cfg_file tls_config to_json verbose attempts =
          end
       )
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_list_namespaces_by_id_cmd =
   Term.(pure alba_list_namespaces_by_id
@@ -106,7 +106,7 @@ let recover_namespace cfg_file tls_config namespace nsm_host_id verbose =
       (fun client ->
          client # recover_namespace ~namespace ~nsm_host_id)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let recover_namespace_cmd =
   Term.(pure recover_namespace
@@ -165,7 +165,7 @@ let alba_list_osds cfg_file tls_config node_id to_json verbose attempts =
              devices'
          end)
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let node_id default =
   let doc = "the $(docv) just for this node" in
@@ -236,7 +236,7 @@ let alba_list_all_osds alba_cfg_url tls_config node_id to_json verbose attempts 
              devices'
          end)
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_list_all_osds_cmd =
   let alba_list_all_osds_t =
@@ -275,7 +275,7 @@ let alba_list_available_osds alba_cfg_file tls_config to_json verbose attempts =
         cnt
         ([%show : Nsm_model.OsdInfo.t list] osds)
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_list_available_osds_cmd =
   Term.(pure alba_list_available_osds
@@ -311,7 +311,7 @@ let alba_list_nsm_hosts cfg_file tls_config to_json verbose attempts =
         ([%show: (string * Albamgr_protocol.Protocol.Nsm_host.t * int64) list]
            nsm_hosts)
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_list_nsm_hosts_cmd =
   Term.(pure alba_list_nsm_hosts
@@ -334,7 +334,7 @@ let alba_add_nsm_host alba_cfg_url tls_config nsm_host_cfg_url to_json verbose a
                 ~nsm_host_id
                 ~nsm_host_info:Nsm_host.({ kind = (Arakoon cfg); lost = false; }))
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_add_nsm_host_cmd =
   Term.(pure alba_add_nsm_host
@@ -363,7 +363,7 @@ let alba_update_nsm_host
                 ~nsm_host_id
                 ~nsm_host_info:Nsm_host.({ kind = (Arakoon cfg); lost; }))
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_update_nsm_host_cmd =
   Term.(pure alba_update_nsm_host
@@ -389,7 +389,7 @@ let alba_mgr_get_version cfg_file tls_config verbose attempts =
        Lwt_io.printlf "(%i, %i, %i, %S)" major minor patch hash
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_mgr_get_version_cmd =
   Term.(pure alba_mgr_get_version
@@ -411,7 +411,7 @@ let alba_mgr_statistics cfg_file tls_config attempts clear verbose =
        Lwt_io.printlf "%s" (Albamgr_plugin.Statistics.show statistics)
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_mgr_statistics_cmd =
   Term.(pure alba_mgr_statistics
@@ -452,7 +452,7 @@ let alba_list_decommissioning_osds
              cnt
              ([%show : (Osd.id * Nsm_model.OsdInfo.t) list] osds))
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_list_decommissioning_osds_cmd =
   Term.(pure alba_list_decommissioning_osds
@@ -477,7 +477,7 @@ let alba_list_participants cfg_file tls_config prefix verbose =
          cnt
          ([%show : (string*int) list] participants))
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_list_participants_cmd =
   let prefix = Arg.(required
@@ -520,7 +520,7 @@ let alba_list_work cfg_file tls_config verbose attempts =
        end
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_list_work_cmd =
   Term.(pure alba_list_work
@@ -572,7 +572,7 @@ let alba_add_osd cfg_file tls_config host port node_id to_json verbose attempts 
          (fun client -> client # add_osd osd_info
          )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_add_osd_cmd =
   Term.(pure alba_add_osd
@@ -607,7 +607,7 @@ let alba_add_iter_namespace_item cfg_file tls_config namespace name factor actio
                             name,
                             factor)) ])
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_rewrite_namespace cfg_file tls_arg namespace name factor verbose =
   alba_add_iter_namespace_item
@@ -683,7 +683,7 @@ let alba_show_job_progress cfg_file tls_config name verbose =
             ([%show : Albamgr_protocol.Protocol.Progress.t] p))
          progresses)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_show_job_progress_cmd =
   Term.(pure alba_show_job_progress
@@ -711,7 +711,7 @@ let alba_clear_job_progress cfg_file tls_config name verbose =
           client # update_progress name p None)
          progresses)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_clear_job_progress_cmd =
   Term.(pure alba_clear_job_progress
@@ -738,7 +738,7 @@ let alba_get_maintenance_config cfg_file tls_config to_json verbose =
            "Maintenance config = %s"
            (Maintenance_config.show cfg))
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_get_maintenance_config_cmd =
   Term.(pure alba_get_maintenance_config
@@ -771,7 +771,7 @@ let alba_update_maintenance_config
          "Maintenance config now is %s"
          (Maintenance_config.show maintenance_config))
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_update_maintenance_config_cmd =
   Term.(pure alba_update_maintenance_config
@@ -826,7 +826,7 @@ let alba_get_abm_client_config cfg_file tls_config allow_dirty verbose =
     end >>= fun ccfg ->
     Lwt_log.info_f "Get client config: %s" (Alba_arakoon.Config.show ccfg)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_get_abm_client_config_cmd =
   Term.(pure alba_get_abm_client_config
@@ -846,7 +846,7 @@ let alba_update_abm_client_config cfg_url tls_config verbose attempts =
       (fun client ->
        client # store_client_config cfg)
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let alba_update_abm_client_config_cmd =
   Term.(pure alba_update_abm_client_config

--- a/ocaml/src/cli_nsm_host.ml
+++ b/ocaml/src/cli_nsm_host.ml
@@ -29,7 +29,7 @@ let nsm_host_statistics (cfg_url:Url.t) tls_config clear nsm_host verbose =
        Lwt_io.printlf "%s" (Nsm_host_protocol.Protocol.NSMHStatistics.show statistics)
       )
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let nsm_host_statistics_cmd =
   Term.(pure nsm_host_statistics
@@ -73,7 +73,7 @@ let list_device_objects
           Lwt.return ()
       ))
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 let list_device_objects_cmd =
   let osd_id default =

--- a/ocaml/src/cli_preset.ml
+++ b/ocaml/src/cli_preset.ml
@@ -52,7 +52,7 @@ let alba_create_preset
            preset_name
            preset)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_create_preset_cmd =
   Term.(pure alba_create_preset
@@ -89,7 +89,7 @@ let alba_update_preset
            preset_name
            preset_updates)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_update_preset_cmd =
   Term.(pure alba_update_preset
@@ -111,7 +111,7 @@ let alba_preset_set_default cfg_url tls_config preset_name to_json verbose =
       (fun client ->
          client # set_default_preset preset_name)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_preset_set_default_cmd =
   Term.(pure alba_preset_set_default
@@ -131,7 +131,7 @@ let alba_add_osds_to_preset cfg_url tls_config preset_name osd_ids to_json verbo
       (fun client ->
          client # add_osds_to_preset ~preset_name ~osd_ids)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_add_osds_to_preset_cmd =
   Term.(pure alba_add_osds_to_preset
@@ -158,7 +158,7 @@ let alba_delete_preset cfg_url tls_config preset_name to_json verbose =
       (fun client ->
          client # delete_preset preset_name)
   in
-  lwt_cmd_line_unit to_json verbose t
+  lwt_cmd_line_unit ~to_json ~verbose t
 
 let alba_delete_preset_cmd =
   Term.(pure alba_delete_preset
@@ -188,7 +188,7 @@ let alba_list_presets cfg_url tls_config to_json verbose =
         cnt
         ([%show : (Preset.name * Preset.t * bool * bool) list] presets)
   in
-  lwt_cmd_line to_json verbose t
+  lwt_cmd_line ~to_json ~verbose t
 
 let alba_list_presets_cmd =
   Term.(pure alba_list_presets

--- a/ocaml/src/cli_proxy.ml
+++ b/ocaml/src/cli_proxy.ml
@@ -198,7 +198,7 @@ let proxy_client_cmd_line host port verbose f =
       host port
       f
   in
-  lwt_cmd_line false verbose t
+  lwt_cmd_line ~to_json:false ~verbose t
 
 
 let proxy_list_namespaces host port verbose =

--- a/ocaml/src/osd_bench.ml
+++ b/ocaml/src/osd_bench.ml
@@ -81,6 +81,20 @@ let get_version (client : Osd.osd) progress n _ _ _ _ =
   report "get_version" r
 
 
+let exists (client : Osd.osd) progress n _ _ period prefix =
+  let gen = make_key period prefix in
+  let do_one i =
+    let key = gen () in
+    client # multi_exists
+           Osd.High
+           [ (Slice.wrap_string key) ]
+    >>= fun _ ->
+    Lwt.return_unit
+  in
+  measured_loop progress do_one n >>= fun r ->
+  report "exists" r
+
+
 let _make_value value_size =
   (* TODO: this affects performance as there is compression going
      on inside the database

--- a/ocaml/src/osd_bench.ml
+++ b/ocaml/src/osd_bench.ml
@@ -72,6 +72,15 @@ let partial_reads (client : Osd.osd) progress n _value_size partial_fetch_size p
   report "partial_reads" r
 
 
+let get_version (client : Osd.osd) progress n _ _ _ _ =
+  let do_one _ =
+    client # get_version >>= fun _ ->
+    Lwt.return ()
+  in
+  measured_loop progress do_one n >>= fun r ->
+  report "get_version" r
+
+
 let _make_value value_size =
   (* TODO: this affects performance as there is compression going
      on inside the database

--- a/ocaml/src/proxy_bench.ml
+++ b/ocaml/src/proxy_bench.ml
@@ -98,6 +98,19 @@ let do_deletes
   measured_loop progress do_one n >>= fun r ->
   report "deletes" r
 
+let do_get_version
+      client
+      progress n
+      _ _ _ _ _ =
+  let do_one _ =
+    client # get_version >>= fun _ ->
+    Lwt.return_unit
+  in
+  Lwt_io.printlf "get_version:" >>= fun () ->
+  measured_loop progress do_one n >>= fun r ->
+  report "get_version" r
+
+
 let do_scenarios
       host port
       n_clients n


### PR DESCRIPTION
- bench blobs writing/reading (without network/rocksdb)
- fadvise random for partial read
- detached sendfile (as it could block, despite the earlier attempt at waiting for it to be readable)
- bench get-version (proxy & asd)
- asd bench exists