### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 
 env:
   - SUITE=system2
-  - SUITE=system2 ALBA_TLS=true
+#  - SUITE=system2 ALBA_TLS=true
   - SUITE=disk_failures
   - SUITE=recovery
 

--- a/travis.sh
+++ b/travis.sh
@@ -59,7 +59,7 @@ before_install () {
     sudo apt-key update
 
     echo "Installing general dependencies"
-    sudo apt-get install -qq ${APT_DEPENDS} \
+    sudo apt-get install -q ${APT_DEPENDS} \
          ocaml ocaml-native-compilers camlp4-extra opam
 
     date
@@ -180,6 +180,7 @@ script () {
             ;;
         system2)
             ${TEST_DRIVER} ocaml | tail -n256
+            expr $PIPESTATUS && false
             ;;
         disk_failures)
             ${TEST_DRIVER} disk_failures


### PR DESCRIPTION
- travis should fail if the unit tests fail (fixes a regression introduced in https://github.com/openvstorage/alba/pull/125)
- disable running the tests with tls (as they are broken since merging in #185)