### PR TITLE
no longer use rocksdb_recycle_log_file option

### DIFF
--- a/ocaml/src/asd_test.ml
+++ b/ocaml/src/asd_test.ml
@@ -89,7 +89,7 @@ let with_asd_client ?(is_restart=false) ?write_blobs test_name port f =
            ~slow:false
            ~fsync:false
            ~rocksdb_max_open_files:256
-           ~rocksdb_recycle_log_file_num:(Some 4)
+           ~rocksdb_recycle_log_file_num:None
            ~rocksdb_block_cache_size:None
            ~limit:90L
            ~tls_config

--- a/ocaml/src/cli_asd.ml
+++ b/ocaml/src/cli_asd.ml
@@ -119,7 +119,7 @@ let asd_start cfg_url slow log_sinks =
                             ~multicast
                             ~tls_config
                             ~rocksdb_max_open_files:256
-                            ~rocksdb_recycle_log_file_num:(Some 4)
+                            ~rocksdb_recycle_log_file_num:None
                             ~rocksdb_block_cache_size
                             ~tcp_keepalive
                             ~write_blobs


### PR DESCRIPTION
This fixes #211 and prevents #197 from further happening.
Do note that asds where #197 has occurred will still not be able to be started after this change.
For that an update of rocksdb is needed, but still waiting on https://github.com/facebook/rocksdb/pull/881 to get into a new rocksdb release.
Once rocksdb has been updated the changes in this pull request can be reverted.