### PR TITLE
use all ascii in names of generated namespaces

### DIFF
--- a/ocaml/src/alba_json.ml
+++ b/ocaml/src/alba_json.ml
@@ -86,6 +86,10 @@ module Osd = struct
          "Alba", id,
          (None, None, None, None),
          (Some cfg, Some prefix, Some preset)
+      | OsdInfo.Alba2 { OsdInfo.id; cfg; prefix; preset } ->
+         "Alba2", id,
+         (None, None, None, None),
+         (Some cfg, Some prefix, Some preset)
     in
     { id; alba_id;
       kind;

--- a/ocaml/src/alba_osd.ml
+++ b/ocaml/src/alba_osd.ml
@@ -25,9 +25,14 @@ open Lwt.Infix
 class client
         (alba_client : Alba_client.alba_client)
         ~alba_id ~prefix ~preset_name
+        ~namespace_name_format
   =
-  let to_namespace_name namespace_id =
-    prefix ^ (serialize ~buf_size:4 Llio.int32_be_to namespace_id)
+  let to_namespace_name =
+    match namespace_name_format with
+    | 0 -> fun namespace_id ->
+           prefix ^ (serialize ~buf_size:4 Llio.int32_be_to namespace_id)
+    | 1 -> Printf.sprintf "%s_%09li" prefix
+    | _ -> assert false
   in
   let get_kvs ~consistent_read namespace =
     object(self :# Osd.key_value_storage)
@@ -242,6 +247,7 @@ let rec make_client
           ~prefix
           ~preset_name
           ~albamgr_connection_pool_size
+          ~namespace_name_format
   =
   let albamgr_pool =
     Remotes.Pool.Albamgr.make
@@ -284,7 +290,13 @@ let rec make_client
           alba_client # create_namespace ~namespace ~preset_name () >>= fun _ ->
           Lwt.return ()
      end >>= fun () ->
-     let client = new client alba_client ~alba_id ~prefix ~preset_name in
+     let client =
+       new client
+           alba_client
+           ~alba_id
+           ~prefix ~preset_name
+           ~namespace_name_format
+     in
      Lwt.return ((client :> Osd.osd), closer))
     (fun exn ->
      closer () >>= fun () ->

--- a/ocaml/src/alba_osd_test.ml
+++ b/ocaml/src/alba_osd_test.ml
@@ -27,7 +27,12 @@ let test_with_kvs_client
 
      let prefix = test_name in
      alba_client # create_namespace ~namespace:prefix ~preset_name:None () >>= fun _ ->
-     let client = new Alba_osd.client alba_client ~alba_id ~prefix ~preset_name:None in
+     let client = new Alba_osd.client
+                      alba_client
+                      ~alba_id
+                      ~prefix ~preset_name:None
+                      ~namespace_name_format:1
+     in
      f (client # global_kvs))
 
 let test_set_get_delete () =

--- a/ocaml/src/albamgr_protocol.ml
+++ b/ocaml/src/albamgr_protocol.ml
@@ -178,7 +178,12 @@ module Protocol = struct
           match osd.kind with
           | Asd (conn_info, asd_id)   -> Asd (get_conn_info' conn_info, asd_id)
           | Kinetic (conn_info, k_id) -> Kinetic (get_conn_info' conn_info, k_id)
-          | Alba ({ cfg; _ } as x) -> Alba { x with
+          | Alba  ({ cfg; _ } as x) -> Alba
+                                         { x with
+                                           cfg = Option.get_some_default cfg albamgr_cfg';
+                                         }
+          | Alba2 ({ cfg; _ } as x) -> Alba2
+                                         { x with
                                            cfg = Option.get_some_default cfg albamgr_cfg';
                                          }
         in

--- a/ocaml/src/cli_asd.ml
+++ b/ocaml/src/cli_asd.ml
@@ -424,7 +424,7 @@ let asd_osd_info_from_kind k =
   let open Nsm_model.OsdInfo in
   match k with
   | Asd (x, _) -> x
-  | Kinetic _ | Alba _ -> assert false
+  | Kinetic _ | Alba _ | Alba2 _ -> assert false
 
 let asd_multistatistics long_ids to_json verbose cfg_file tls_config clear =
   begin

--- a/ocaml/src/cli_osd.ml
+++ b/ocaml/src/cli_osd.ml
@@ -133,11 +133,11 @@ let alba_add_osd
            ~tls_config
            ~tcp_keepalive:Tcp_keepalive2.default
            (fun mgr -> mgr # get_alba_id) >>= fun long_id ->
-         Lwt.return Nsm_model.OsdInfo.(Alba { id = long_id;
-                                              cfg = alba_osd_cfg;
-                                              prefix;
-                                              preset;
-                                            })
+         Lwt.return Nsm_model.OsdInfo.(Alba2 { id = long_id;
+                                               cfg = alba_osd_cfg;
+                                               prefix;
+                                               preset;
+                                             })
       | _, _, _, _, _ ->
          failwith "incorrect combination of host, port alba_osd_cfg_url, prefix & preset specified"
     end >>= fun kind ->

--- a/ocaml/src/disk_failure_tests.ml
+++ b/ocaml/src/disk_failure_tests.ml
@@ -56,7 +56,8 @@ let _easiest_upload () =
            let rc = Sys.command cmd in
            Lwt_io.printlf "rc=%i" rc
          end
-      | OsdInfo.Alba _ -> assert false
+      | OsdInfo.Alba _
+      | OsdInfo.Alba2 _ -> assert false
   in
   Alba_arakoon.config_from_url !cfg_url >>= fun cfg ->
   Alba_client2.with_client

--- a/ocaml/src/fragment_cache_alba.ml
+++ b/ocaml/src/fragment_cache_alba.ml
@@ -103,7 +103,7 @@ class alba_cache
     match bucket_strategy with
     | OneOnOne { prefix;
                  preset; } ->
-       let namespace = prefix ^ (serialize ~buf_size:4 Llio.int32_be_to bid) in
+       let namespace = Printf.sprintf "%s_%09li" prefix bid in
        Lwt.catch
          (fun () -> f namespace)
          (fun exn ->

--- a/ocaml/src/nsm_host_protocol.ml
+++ b/ocaml/src/nsm_host_protocol.ml
@@ -48,7 +48,8 @@ module Protocol = struct
                | true, false -> _to_buffer_2
                | _           -> _to_buffer_3
              end
-          | Alba _ ->
+          | Alba _
+          | Alba2 _ ->
              _to_buffer_3
         in
         to_buffer buf osd_info

--- a/ocaml/src/nsm_model.ml
+++ b/ocaml/src/nsm_model.ml
@@ -52,12 +52,14 @@ module OsdInfo = struct
     | Asd     of conn_info * asd_id
     | Kinetic of conn_info * kinetic_id
     | Alba    of alba_cfg
+    | Alba2   of alba_cfg
                    [@@deriving show, yojson]
 
   let get_long_id = function
     | Asd (_, asd_id)         -> asd_id
     | Kinetic (_, kinetic_id) -> kinetic_id
-    | Alba { id; }            -> id
+    | Alba  { id; }
+    | Alba2 { id; }           -> id
 
   type t = {
     kind : kind;
@@ -101,6 +103,12 @@ module OsdInfo = struct
        Llio.string_to buf kin_id
     | Alba { cfg; id; prefix; preset; } ->
        Llio.int8_to buf 3;
+       Alba_arakoon.Config.to_buffer buf cfg;
+       Llio.string_to buf id;
+       Llio.string_to buf prefix;
+       Llio.string_to buf preset
+    | Alba2 { cfg; id; prefix; preset; } ->
+       Llio.int8_to buf 4;
        Alba_arakoon.Config.to_buffer buf cfg;
        Llio.string_to buf id;
        Llio.string_to buf prefix;
@@ -241,6 +249,12 @@ module OsdInfo = struct
         let prefix = Llio.string_from buf in
         let preset = Llio.string_from buf in
         Alba { cfg; id; prefix; preset; }
+      | 4 ->
+        let cfg = Alba_arakoon.Config.from_buffer buf in
+        let id = Llio.string_from buf in
+        let prefix = Llio.string_from buf in
+        let preset = Llio.string_from buf in
+        Alba2 { cfg; id; prefix; preset; }
       | k -> raise_bad_tag "OsdInfo" k in
     let node_id = Llio.string_from buf in
     let decommissioned = Llio.bool_from buf in
@@ -280,6 +294,12 @@ module OsdInfo = struct
         let prefix = Llio.string_from buf in
         let preset = Llio.string_from buf in
         Alba { cfg; id; prefix; preset; }
+      | 4 ->
+        let cfg = Alba_arakoon.Config.from_buffer buf in
+        let id = Llio.string_from buf in
+        let prefix = Llio.string_from buf in
+        let preset = Llio.string_from buf in
+        Alba2 { cfg; id; prefix; preset; }
       | k -> raise_bad_tag "OsdInfo" k
     in
     let node_id = Llio.string_from buf in
@@ -328,6 +348,12 @@ module OsdInfo = struct
         let prefix = Llio.string_from buf in
         let preset = Llio.string_from buf in
         Alba { cfg; id; prefix; preset; }
+      | 4 ->
+        let cfg = Alba_arakoon.Config.from_buffer buf in
+        let id = Llio.string_from buf in
+        let prefix = Llio.string_from buf in
+        let preset = Llio.string_from buf in
+        Alba2 { cfg; id; prefix; preset; }
       | k -> raise_bad_tag "OsdInfo" k
     in
     let node_id = Llio.string_from buf in

--- a/ocaml/src/osd_access.ml
+++ b/ocaml/src/osd_access.ml
@@ -42,6 +42,7 @@ module Osd_pool = struct
                                tcp_keepalive:Tcp_keepalive.t ->
                                prefix:string ->
                                preset_name:Albamgr_protocol.Protocol.Preset.name option ->
+                               namespace_name_format:int ->
                                (Osd'.osd * (unit -> unit Lwt.t)) Lwt.t;
       }
 
@@ -68,7 +69,8 @@ module Osd_pool = struct
       function
       | Asd _
       | Kinetic _ -> false
-      | Alba _ -> true
+      | Alba _
+      | Alba2 _ -> true
 
     let factory tls_config tcp_keepalive buffer_pool make_alba_osd_client =
       function
@@ -95,6 +97,14 @@ module Osd_pool = struct
            ~tls_config
            ~tcp_keepalive
            ~prefix ~preset_name:(Some preset)
+           ~namespace_name_format:0
+      | OsdInfo.Alba2 { Nsm_model.OsdInfo.cfg; id; prefix; preset; } ->
+         make_alba_osd_client
+           (ref cfg)
+           ~tls_config
+           ~tcp_keepalive
+           ~prefix ~preset_name:(Some preset)
+           ~namespace_name_format:1
 
     let use_osd t ~(osd_id:int32) f =
       let get_pool kind =
@@ -559,7 +569,8 @@ class osd_access
                     match osd_info.kind with
                     | Asd (x, _)
                     | Kinetic (x, _) -> x
-                    | Alba _ -> assert false (* Alba osds don't broadcast *)
+                    | Alba _
+                    | Alba2 _ -> assert false (* Alba osds don't broadcast *)
                   in
                   let () =
                     if conn_info' <> conn_info

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -2162,7 +2162,7 @@ module Test = struct
     t_hdd.proxy # upload_object "demo" cfg_hdd.alba_bin objname;
 
     let output = t_ssd.proxy # list_namespaces in
-    assert (output = "Found 2 namespaces: [\"demo\"; \"my_prefix\\000\\000\\000\\000\"]");
+    assert (output = "Found 2 namespaces: [\"demo\"; \"my_prefix_000000000\"]");
 
     begin
       (* verify that the cache backend knows it is used as a cache! *)
@@ -2248,7 +2248,11 @@ module Test = struct
       |> Yojson.Basic.from_string
       |> Yojson.Basic.Util.member "result"
       |> function
-        | `List namespaces -> assert (3 = List.length namespaces)
+        | `List namespaces ->
+           Printf.printf "namespaces = %s\n" (Yojson.Basic.to_string (`List namespaces));
+           assert (3 = List.length namespaces);
+           assert (Yojson.Basic.to_string (`List namespaces) =
+                     "namespaces = [{\"id\":1,\"name\":\"alba_osd_prefix\",\"nsm_host_id\":\"nsm\",\"state\":\"active\",\"preset_name\":\"default\"},{\"id\":2,\"name\":\"alba_osd_prefix_000000000\",\"nsm_host_id\":\"nsm\",\"state\":\"active\",\"preset_name\":\"default\"},{\"id\":0,\"name\":\"demo\",\"nsm_host_id\":\"nsm\",\"state\":\"active\",\"preset_name\":\"default\"}]")
         | _ -> assert false
     end;
 

--- a/travis.sh
+++ b/travis.sh
@@ -25,7 +25,7 @@ OPAM_DEPENDS="ocamlfind \
          kinetic-client \
          tiny_json \
          cmdliner \
-         ppx_deriving ppx_deriving_yojson \
+         ppx_deriving.3.3 ppx_deriving_yojson.2.4 \
          sexplib.113.00.00 \
          core.113.00.00 \
          conf-libev \


### PR DESCRIPTION
fixes #260 