### PR TITLE
quick fix for #307

### DIFF
--- a/ocaml/src/nsm_model.ml
+++ b/ocaml/src/nsm_model.ml
@@ -1104,14 +1104,14 @@ module NamespaceManager(C : Constants)(KV : Read_key_value_store) = struct
              in
 
              let cnt' = cnt + 1 in
-             if cnt' > max_disks_per_node
-             then Err.(failwith
-                         ~payload:(Printf.sprintf
-                                     "Attempting to use %i disks of node %s while max %i permitted (%s)"
-                                     cnt' node_id max_disks_per_node
-                                     ([%show : int32 option list]
-                                        (List.map fst chunk_location)))
-                         Too_many_disks_per_node);
+             (* if cnt' > max_disks_per_node *)
+             (* then Err.(failwith *)
+             (*             ~payload:(Printf.sprintf *)
+             (*                         "Attempting to use %i disks of node %s while max %i permitted (%s)" *)
+             (*                         cnt' node_id max_disks_per_node *)
+             (*                         ([%show : int32 option list] *)
+             (*                            (List.map fst chunk_location))) *)
+             (*             Too_many_disks_per_node); *)
 
              Hashtbl.replace osds_per_node node_id cnt';
              (effective_fragment_count + 1,


### PR DESCRIPTION
This removes the failing assert, which isn't strictly necessary.
It is (was) there to detect buggy clients and prevent them from doing damage. In #307 it was observed that the check is incorrect, preventing valid uploads/repairs from succeeding.
It hasn't detected buggy clients in a long time, but maybe we still want to invest the time to make it work again as it should at a later time.
For now this fix should do.