### PR TITLE
Don't invalidate alba_osd clients

### DIFF
--- a/ocaml/src/albamgr_protocol.ml
+++ b/ocaml/src/albamgr_protocol.ml
@@ -187,16 +187,24 @@ module Protocol = struct
             in
             conn_info'
           in
+          let get_cfg cfg =
+            match albamgr_cfg' with
+            | None -> cfg
+            | Some cfg' ->
+               (* cluster_id shouldn't change! *)
+               assert (fst cfg = fst cfg');
+               cfg'
+          in
           match osd.kind with
           | Asd (conn_info, asd_id)   -> Asd (get_conn_info' conn_info, asd_id)
           | Kinetic (conn_info, k_id) -> Kinetic (get_conn_info' conn_info, k_id)
           | Alba  ({ cfg; _ } as x) -> Alba
                                          { x with
-                                           cfg = Option.get_some_default cfg albamgr_cfg';
+                                           cfg = get_cfg cfg;
                                          }
           | Alba2 ({ cfg; _ } as x) -> Alba2
                                          { x with
-                                           cfg = Option.get_some_default cfg albamgr_cfg';
+                                           cfg = get_cfg cfg;
                                          }
         in
         let max_n = 10 in

--- a/ocaml/src/osd_access.ml
+++ b/ocaml/src/osd_access.ml
@@ -157,18 +157,20 @@ module Osd_pool = struct
         begin
           Lwt_pool2.finalize (Hashtbl.find t.client_pools osd_id) |> Lwt.ignore_result;
           Hashtbl.remove t.client_pools osd_id
-        end;
-      if Hashtbl.mem t.thread_safe_clients osd_id
-      then
-        begin
-          let osd_closer_t = Hashtbl.find t.thread_safe_clients osd_id in
-          Lwt.ignore_result
-            begin
-              osd_closer_t >>= fun (osd, closer) ->
-              closer ()
-            end;
-          Hashtbl.remove t.thread_safe_clients osd_id
         end
+      (* explicitly not invalidating alba_osd clients, as that
+       * should never be necessary. *)
+      (* if Hashtbl.mem t.thread_safe_clients osd_id *)
+      (* then *)
+      (*   begin *)
+      (*     let osd_closer_t = Hashtbl.find t.thread_safe_clients osd_id in *)
+      (*     Lwt.ignore_result *)
+      (*       begin *)
+      (*         osd_closer_t >>= fun (osd, closer) -> *)
+      (*         closer () *)
+      (*       end; *)
+      (*     Hashtbl.remove t.thread_safe_clients osd_id *)
+      (*   end *)
 
     let invalidate_all t =
       List.iter


### PR DESCRIPTION
```
2016-08-10 18:09:04 262746 +0200 - perf-roub-03 - 17640/0 - alba/proxy - 60 - info - Could not yet requalify osd 1, trying again in 1.000000 seconds: (Failure "attempting to use a resource from a pool which is being finalized"); backtrace:; Raised at file "format.ml", line 185, characters 41-52; Called from file "format.ml", line 427, characters 6-24
2016-08-10 18:09:04 471812 +0200 - perf-roub-03 - 17640/0 - alba/proxy - 61 - info - generic propagation ...: (Failure "attempting to use a resource from a pool which is being finalized"); backtrace:; Raised at file "queue.ml", line 86, characters 29-34; Called from file "src/tools/lwt_pool2.ml", line 98, characters 25-46
2016-08-10 18:09:04 471862 +0200 - perf-roub-03 - 17640/0 - alba/proxy - 62 - info - Unexpected exception in proxy while handling request: (Failure "attempting to use a resource from a pool which is being finalized"); backtrace:; Raised at file "format.ml", line 185, characters 41-52; Called from file "format.ml", line 427, characters 6-24
```