### PR TITLE
take eofbit into account too when evaluating state of an input/output stream

### DIFF
--- a/cpp/include/llio.h
+++ b/cpp/include/llio.h
@@ -123,7 +123,7 @@ public:
     output_using([&](const char *buffer, const int len)
                      -> void { os.write(buffer, len); });
     os.flush();
-    if (!os) {
+    if (!os.good()) {
       throw output_stream_exception("invalid outputstream");
     }
   }

--- a/cpp/src/lib/llio.cc
+++ b/cpp/src/lib/llio.cc
@@ -22,7 +22,7 @@ namespace alba {
 namespace llio {
 
 void check_stream(const std::istream &is) {
-  if (!is) {
+  if (!is.good()) {
     throw input_stream_exception("invalid inputstream");
   }
 }


### PR DESCRIPTION
This probably explains #320 and #321 