### PR TITLE
Bench improvements

### DIFF
--- a/ocaml/src/alba_bench.ml
+++ b/ocaml/src/alba_bench.ml
@@ -76,21 +76,30 @@ let do_scenarios
     ~populate_osds_info_cache:true
     albamgr_cfg
     (fun alba_client ->
-     let client = new alba_bench_client alba_client in
-     Lwt_list.iter_s
-       (fun scenario ->
-        let progress = make_progress (n/100) in
-        Lwt_list.iter_p
-          (fun i ->
-           scenario
-             client
-             progress
-             (n/n_clients)
-             file_name
-             period
-             (Printf.sprintf "%s_%i" prefix i)
-             slice_size
-             namespace
-          )
-          (Int.range 0 n_clients))
-       scenarios)
+      let client = new alba_bench_client alba_client in
+      Lwt_list.iter_s
+        (fun scenario ->
+          let step = n / 100 in
+          let progress = make_progress step in
+          let n_per_client = n / n_clients in
+          Lwt_list.iter_p
+            (fun i ->
+              let client_fn = Printf.sprintf "./client_%03i.out" i in
+              Lwt_io.with_file
+                ~mode:Lwt_io.output
+                ~flags:[Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND; Unix.O_NONBLOCK]
+                client_fn
+                (fun oc ->
+                  scenario
+                    ~oc
+                    client
+                    progress
+                    n_per_client
+                    file_name
+                    period
+                    (Printf.sprintf "%s_%i" prefix i)
+                    slice_size
+                    namespace)
+            )
+            (Int.range 0 n_clients))
+        scenarios)

--- a/ocaml/src/alba_bench.ml
+++ b/ocaml/src/alba_bench.ml
@@ -68,7 +68,7 @@ end
 let do_scenarios
       albamgr_cfg
       n_clients n
-      file_name power prefix process_prefix
+      file_name power prefix client_file_prefix
       slice_size namespace
       scenarios =
   let period = period_of_power power in
@@ -83,7 +83,7 @@ let do_scenarios
           let client_fn =
             Printf.sprintf
               "./%s.client_%03i.out"
-              process_prefix
+              client_file_prefix
               i
           in
           Lwt_io.open_file ~mode:Lwt_io.output

--- a/ocaml/src/cli_bench.ml
+++ b/ocaml/src/cli_bench.ml
@@ -106,7 +106,7 @@ let proxy_bench_cmd =
 
 let alba_bench alba_cfg_url tls_config
                n_clients n file_name power
-               prefix process_prefix
+               prefix client_file_prefix
                slice_size namespace
                scenarios robust
   =
@@ -121,7 +121,7 @@ let alba_bench alba_cfg_url tls_config
         ~tls_config
         n_clients n
         file_name power
-        prefix process_prefix
+        prefix client_file_prefix
         slice_size namespace
         mapped
     )
@@ -135,7 +135,7 @@ let alba_bench_cmd =
         $ files
         $ power 4
         $ prefix ""
-        $ process_prefix "0"
+        $ client_file_prefix "0"
         $ slice_size 4096
         $ namespace 0
         $ scenarios

--- a/ocaml/src/cli_bench.ml
+++ b/ocaml/src/cli_bench.ml
@@ -76,11 +76,13 @@ let proxy_bench host port transport
   lwt_cmd_line
     ~to_json:false ~verbose:false
     (fun () ->
-     Proxy_bench.do_scenarios
-       host port transport
-       n_clients n
-       file_names power prefix slice_size namespace_name
-       (map_scenarios scenarios robust))
+      let mapped = map_scenarios scenarios robust in
+      Proxy_bench.do_scenarios
+        host port transport
+        n_clients n
+        file_names power prefix slice_size namespace_name
+        mapped
+    )
 
 let files =
   Arg.(value
@@ -110,14 +112,16 @@ let alba_bench alba_cfg_url tls_config
   lwt_cmd_line
     ~to_json:false ~verbose:false
     (fun () ->
-     let open Lwt.Infix in
-     Alba_arakoon.config_from_url alba_cfg_url >>= fun cfg ->
-     Alba_bench.do_scenarios
-       (ref cfg)
-       ~tls_config
-       n_clients n
-       file_name power prefix slice_size namespace
-       (map_scenarios scenarios robust))
+      let open Lwt.Infix in
+      let mapped = map_scenarios scenarios robust in
+      Alba_arakoon.config_from_url alba_cfg_url >>= fun cfg ->
+      Alba_bench.do_scenarios
+        (ref cfg)
+        ~tls_config
+        n_clients n
+        file_name power prefix slice_size namespace
+        mapped
+    )
 
 let alba_bench_cmd =
   Term.(pure alba_bench

--- a/ocaml/src/cli_bench.ml
+++ b/ocaml/src/cli_bench.ml
@@ -106,7 +106,8 @@ let proxy_bench_cmd =
 
 let alba_bench alba_cfg_url tls_config
                n_clients n file_name power
-               prefix slice_size namespace
+               prefix process_prefix
+               slice_size namespace
                scenarios robust
   =
   lwt_cmd_line
@@ -119,7 +120,9 @@ let alba_bench alba_cfg_url tls_config
         (ref cfg)
         ~tls_config
         n_clients n
-        file_name power prefix slice_size namespace
+        file_name power
+        prefix process_prefix
+        slice_size namespace
         mapped
     )
 
@@ -132,6 +135,7 @@ let alba_bench_cmd =
         $ files
         $ power 4
         $ prefix ""
+        $ process_prefix "0"
         $ slice_size 4096
         $ namespace 0
         $ scenarios

--- a/ocaml/src/cli_bench_common.ml
+++ b/ocaml/src/cli_bench_common.ml
@@ -45,11 +45,14 @@ let prefix default =
        & info ["prefix"] ~docv:"prefix" ~doc
   )
 
-let process_prefix default =
-  let doc = "$(docv) to keep multiple bench processes out of each other's way" in
+let client_file_prefix default =
+  let doc =
+    "prepend the client output files with $(docv)"
+    ^  " to keep multiple processes out of each other's way"
+  in
   Arg.(value
        & opt string default
-       & info ["process-prefix"] ~docv:"process-prefix" ~doc
+       & info ["client-file-prefix"] ~docv:"CLIENT_FILE_PREFIX" ~doc
   )
 
 let value_size default =

--- a/ocaml/src/cli_bench_common.ml
+++ b/ocaml/src/cli_bench_common.ml
@@ -45,6 +45,13 @@ let prefix default =
        & info ["prefix"] ~docv:"prefix" ~doc
   )
 
+let process_prefix default =
+  let doc = "$(docv) to keep multiple bench processes out of each other's way" in
+  Arg.(value
+       & opt string default
+       & info ["process-prefix"] ~docv:"process-prefix" ~doc
+  )
+
 let value_size default =
   let doc = "do sets of $(docv) bytes" in
   Arg.(

--- a/ocaml/src/generic_bench.ml
+++ b/ocaml/src/generic_bench.ml
@@ -18,8 +18,9 @@ but WITHOUT ANY WARRANTY of any kind.
 
 open Lwt.Infix
 
-let report oc name (d,speed, latency, min_d, max_d) =
-  Lwt_io.fprintlf oc "\n%s" name >>= fun () ->
+let report oc name (n, d,speed, latency, min_d, max_d) =
+  Lwt_io.fprintlf oc "\n'%s' summary:" name >>= fun () ->
+  Lwt_io.fprintlf oc "\tn: %i" n >>= fun () ->
   Lwt_io.fprintlf oc "\ttook: %fs or (%f /s)" d speed >>= fun () ->
   Lwt_io.fprintlf oc "\tlatency: %fms" (latency *. 1000.0) >>= fun () ->
   Lwt_io.fprintlf oc "\tmin: %fms" (min_d *. 1000.0) >>= fun () ->
@@ -66,12 +67,12 @@ let measured_loop oc progress f n =
   let nf = float n in
   let speed = nf /. d in
   let latency = d /. nf in
-  Lwt.return (d,speed, latency, min_d, max_d)
+  Lwt.return (n, d,speed, latency, min_d, max_d)
 
 
 
 let measure_and_report oc progress do_one n (scenario_name:string) =
-  Lwt_io.fprintl oc scenario_name >>= fun () ->
+  Lwt_io.fprintlf oc "'%s' progress:" scenario_name >>= fun () ->
   measured_loop oc progress do_one n >>= fun r ->
   report oc scenario_name r
 

--- a/ocaml/src/osd_bench.ml
+++ b/ocaml/src/osd_bench.ml
@@ -23,12 +23,14 @@ open Generic_bench
 open Checksum
 open Slice
 
+let oc = Lwt_io.stdout
 
 let maybe_fail = function
   | Osd.Ok -> Lwt.return_unit
   | Osd.Exn e -> Osd.Error.lwt_fail e
 
 let deletes with_client progress n value_size _ period prefix =
+
   let run client =
       let gen = make_key period prefix in
       let do_one i =
@@ -39,8 +41,8 @@ let deletes with_client progress n value_size _ period prefix =
         client # global_kvs # apply_sequence
                Osd.High [] updates >>= maybe_fail
       in
-      measured_loop progress do_one n >>= fun r ->
-      report "deletes" r
+      measured_loop oc progress do_one n >>= fun r ->
+      report oc "deletes" r
   in
   with_client run
 
@@ -59,8 +61,8 @@ let gets with_client progress n value_size _ period prefix =
         in
         Lwt.return ()
       in
-      measured_loop progress do_one n >>= fun r ->
-      report "gets" r
+      measured_loop oc progress do_one n >>= fun r ->
+      report oc "gets" r
   in
   with_client run
 
@@ -79,8 +81,8 @@ let partial_reads with_client progress n _value_size partial_fetch_size period p
       | Osd.NotFound -> failwith "partial read key not found"
       | Osd.Success -> Lwt.return_unit
     in
-    measured_loop progress do_one n >>= fun r ->
-    report "partial_reads" r
+    measured_loop oc progress do_one n >>= fun r ->
+    report oc "partial_reads" r
   in
   with_client run
 
@@ -91,8 +93,8 @@ let get_version with_client progress n _ _ _ _ =
       client # get_version >>= fun _ ->
       Lwt.return ()
     in
-    measured_loop progress do_one n >>= fun r ->
-    report "get_version" r
+    measured_loop oc progress do_one n >>= fun r ->
+    report oc "get_version" r
   in
   with_client run
 
@@ -109,8 +111,8 @@ let churn with_client progress n _ _ _ _ =
           (fun exn -> Lwt.fail exn)
       )
   in
-  measured_loop progress do_one n >>= fun r ->
-  report "churn" r
+  measured_loop oc progress do_one n >>= fun r ->
+  report oc "churn" r
 
 
 let exists with_client progress n _ _ period prefix =
@@ -124,8 +126,8 @@ let exists with_client progress n _ _ period prefix =
       >>= fun _ ->
       Lwt.return_unit
     in
-    measured_loop progress do_one n >>= fun r ->
-    report "exists" r
+    measured_loop oc progress do_one n >>= fun r ->
+    report oc "exists" r
   in
   with_client run
 
@@ -160,8 +162,8 @@ let sets with_client progress n value_size _ period prefix =
       let updates = [set] in
       client # global_kvs # apply_sequence Osd.High [] updates >>= maybe_fail
     in
-    measured_loop progress do_one n >>= fun r ->
-    report "sets" r
+    measured_loop oc progress do_one n >>= fun r ->
+    report oc "sets" r
   in
   with_client run
 
@@ -176,8 +178,8 @@ let range_queries with_client progress n value_size _ period prefix =
       >>= fun keys ->
       Lwt.return ()
     in
-    measured_loop progress do_one n >>= fun r ->
-    report "ranges" r
+    measured_loop oc progress do_one n >>= fun r ->
+    report oc "ranges" r
   in
   with_client run
 
@@ -250,8 +252,8 @@ let upload_fragments with_client progress n value_size _ period prefix =
                                             Osd.High
                                             asserts updates >>= maybe_fail
     in
-    measured_loop progress do_one n >>= fun r ->
-    report "uploads" r
+    measured_loop oc progress do_one n >>= fun r ->
+    report oc "uploads" r
   in
   with_client run
 

--- a/ocaml/src/proxy_bench.ml
+++ b/ocaml/src/proxy_bench.ml
@@ -134,7 +134,7 @@ let do_scenarios
   let period = period_of_power power in
   Lwt_list.iter_s
     (fun scenario ->
-      let step = n / 100 in
+      let step = max (n / 100) 1 in
       let progress = make_progress step  in
       Lwt_list.iter_p
         (fun i ->

--- a/ocaml/src/proxy_bench.ml
+++ b/ocaml/src/proxy_bench.ml
@@ -20,8 +20,10 @@ open Prelude
 open Lwt.Infix
 open Generic_bench
 
-
-let do_writes ~robust client progress n input_files period prefix _ namespace =
+let do_writes
+      ~robust ~oc
+      client progress n input_files period prefix _ namespace
+  =
   let gen = make_key period prefix in
   let no_files = List.length input_files in
   if no_files = 0
@@ -61,11 +63,11 @@ let do_writes ~robust client progress n input_files period prefix _ namespace =
        then inner 1.
        else Lwt.fail exn)
   in
-  Lwt_io.printlf "writes (robust=%b):" robust >>= fun () ->
-  measured_loop progress do_one n >>= fun r ->
-  report "writes" r
+  measure_and_report oc progress do_one n "writes"
+
 
 let do_reads
+      ~oc
       client
       progress n _ period prefix
       (_:int) namespace =
@@ -80,11 +82,10 @@ let do_reads
            ~consistent_read:false
            ~should_cache:true
   in
-  Lwt_io.printlf "reads:" >>= fun () ->
-  measured_loop progress do_one n >>= fun r ->
-  report "reads" r
+  measure_and_report oc progress do_one n "reads"
 
 let do_partial_reads
+      ~oc
       client
       progress n _ period prefix
       (slice_size:int) namespace =
@@ -99,11 +100,10 @@ let do_partial_reads
     >>= fun _data ->
     Lwt.return ()
   in
-  Lwt_io.printlf "partial reads:" >>= fun () ->
-  measured_loop progress do_one n >>=fun r ->
-  report "partial reads" r
+  measure_and_report oc progress do_one n "partial reads"
 
 let do_deletes
+      ~oc
       client
       progress n _ period prefix
       (_:int) namespace =
@@ -112,11 +112,10 @@ let do_deletes
     let object_name = gen ()  in
     client # delete_object ~namespace ~object_name ~may_not_exist:false
   in
-  Lwt_io.printlf "deletes:" >>= fun () ->
-  measured_loop progress do_one n >>= fun r ->
-  report "deletes" r
+  measure_and_report oc progress do_one n "deletes"
 
 let do_get_version
+      ~oc
       client
       progress n
       _ _ _ _ _ =
@@ -124,9 +123,7 @@ let do_get_version
     client # get_version >>= fun _ ->
     Lwt.return_unit
   in
-  Lwt_io.printlf "get_version:" >>= fun () ->
-  measured_loop progress do_one n >>= fun r ->
-  report "get_version" r
+  measure_and_report oc progress do_one n "get_version"
 
 
 let do_scenarios
@@ -137,21 +134,25 @@ let do_scenarios
   let period = period_of_power power in
   Lwt_list.iter_s
     (fun scenario ->
-     let progress = make_progress (n/100) in
-     Lwt_list.iter_p
-       (fun i ->
-        Proxy_client.with_client
-          host port transport
-          (fun client ->
-           scenario
-             client
-             progress
-             (n/n_clients)
-             file_names
-             period
-             (Printf.sprintf "%s_%i" prefix i)
-             slice_size
-             namespace
-          ))
-       (Int.range 0 n_clients))
+      let step = n / 100 in
+      let progress = make_progress step  in
+      Lwt_list.iter_p
+        (fun i ->
+          Proxy_client.with_client
+            host port transport
+            (fun client ->
+              let oc = Lwt_io.stdout in
+              let per_client = n / n_clients in
+              scenario
+                ~oc
+                client
+                progress
+                per_client
+                file_names
+                period
+                (Printf.sprintf "%s_%i" prefix i)
+                slice_size
+                namespace
+        ))
+        (Int.range 0 n_clients))
     scenarios


### PR DESCRIPTION
- `alba-bench` output of different clients to different files (and a process prefix)
   (we might want this for the other benchmarks too)
- `multi-delete` allows you to clean up after a killed osd bench