### PR TITLE
catch ensure namespace race

### DIFF
--- a/ocaml/src/fragment_cache_alba.ml
+++ b/ocaml/src/fragment_cache_alba.ml
@@ -172,8 +172,14 @@ class alba_cache
        Lwt.catch
          (fun () -> f namespace)
          (fun exn ->
-          client # create_namespace ~namespace ~preset_name:(Some preset) () >>= fun _ ->
-          f namespace)
+           Lwt.catch
+             (client # create_namespace ~namespace ~preset_name:(Some preset))
+             (let open Albamgr_protocol.Protocol.Error in
+              function
+              | Albamgr_exn (Namespace_already_exists, _) -> Lwt.return 0l
+              | exn -> Lwt.fail exn)
+           >>= fun _ ->
+           f namespace)
   in
   object(self)
     inherit Fragment_cache.cache


### PR DESCRIPTION
Avoids clusters of this error:
```
Nov 15 01:56:00 ftcmp02 alba[28561]: 2016-11-15 01:56:00 296291 +0100 - ftcmp02 - 28561/0 - alba/proxy - 114259 - info - Exception while adding object to alba fragment cache: Albamgr_protocol.Protocol.Error.Albamgr_exn(4, "Albamgr_protocol.Protocol.Error.Namespace_already_exists"); backtrace:; Raised at file "queue.ml", line 68, characters 17-22; Called from file "src/tools/lwt_pool2.ml", line 98, characters 25-46
```