### PR TITLE
build/ci improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ script:         ./travis.sh script
 services:
   - docker
 
-cache:
-  directories:
-    - ~/cache
-  timeout:
-    1000
+# cache:
+#   directories:
+#     - ~/cache
+#   timeout:
+#     1000

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,10 @@ clean:
               ./ocaml/disk_failure_tests.native
 
 
-build: build-alba build-cmxs build-nsm-plugin build-mgr-plugin \
-	build-disk-failure-tests setup
+build: build-alba build-cmxs build-nsm-plugin build-mgr-plugin setup
 
 build-alba:
-	cd ocaml && ocamlbuild -j 0 -use-ocamlfind alba.native
+	cd ocaml && ocamlbuild -j 0 -use-ocamlfind alba.native disk_failure_tests.native
 
 build-cmxs: build-alba
 	cd ocaml && ocamlbuild -use-ocamlfind \
@@ -97,9 +96,6 @@ build-mgr-plugin: build-alba
 	-linkpkg -package uuidm \
         -linkpkg -package result \
 	-shared -o albamgr_plugin.cmxs
-
-build-disk-failure-tests: build-alba
-	cd ocaml && ocamlbuild -use-ocamlfind disk_failure_tests.native
 
 setup:
 	cd ./setup && ocamlbuild -use-ocamlfind setup.native

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,5 +16,5 @@ fi
 
 # finally execute the command the user requested
 
-command="cd alba && arakoon_url=${arakoon_url:=no-arakoon-url} alba_url=${alba_url:=no-alba-url} ./jenkins/run2.sh $@"
+command="cd alba && arakoon_url=${arakoon_url:=no-arakoon-url} alba_url=${alba_url:=no-alba-url} TRAVIS=${TRAVIS:=false} ./jenkins/run2.sh $@"
 sudo -E -i -u jenkins bash -l -c "${command}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -17,6 +17,7 @@ fi
 docker run -i $TTY --privileged=true -e UID=${UID} \
        --env ALBA_TLS --env ALBA_USE_ETCD --env ALBA_USE_GIOEXECFILE \
        --env arakoon_url --env alba_url \
+       --env TRAVIS \
        -v ${PWD}:/home/jenkins/alba \
        alba_$IMAGE \
        bash $@

--- a/jenkins/run2.sh
+++ b/jenkins/run2.sh
@@ -9,13 +9,14 @@ export DRIVER=./setup/setup.native
 
 export ARAKOON_BIN=$(which arakoon)
 
-if [ -t 1 ];
-then TTY="-t";
+if [ -t 1 ]
+then true;
 else
     # this path is taken on jenkins, clean previous builds first
-    TTY="";
-    make clean || true;
-    make || true;
+    make clean
+    if [[ ${1-bash} != "package_"* ]]
+    then make
+    fi
 fi
 
 if (${ALBA_USE_ETCD:-false} -eq true)

--- a/jenkins/run2.sh
+++ b/jenkins/run2.sh
@@ -39,31 +39,47 @@ function package_debian {
     fi
 }
 
+function check_results {
+    if [[ "${TRAVIS-false}" == "true" ]] && ! grep "errors=\"0\" failures=\"0\"" testresults.xml
+    then
+        cat testresults.xml
+        exit 1
+    fi
+}
+
 case "${1-bash}" in
     asd_start)
         ${DRIVER} asd_start || true
+        check_results
         ;;
     cpp)
         ./jenkins/cpp/010-build_client.sh
         ${DRIVER} cpp  || true
+        check_results
         ;;
     ocaml)
         ${DRIVER} ocaml || true
+        check_results
         ;;
     stress)
         ${DRIVER} stress || true
+        check_results
         ;;
     voldrv_backend)
         ${DRIVER} voldrv_backend || true
+        check_results
         ;;
     voldrv_tests)
         ${DRIVER} voldrv_tests || true
+        check_results
         ;;
     disk_failures)
         ${DRIVER} disk_failures || true
+        check_results
         ;;
     compat)
         ${DRIVER} compat || true
+        check_results
         ;;
     recovery)
         find cfg/*.ini -exec sed -i "s,/tmp,${WORKSPACE}/tmp,g" {} \;
@@ -71,6 +87,7 @@ case "${1-bash}" in
         ;;
     everything_else)
         ${DRIVER} everything_else  || true
+        check_results
         ;;
     test_integrate_deb)
         ./jenkins/run.sh test_integrate_deb

--- a/travis.sh
+++ b/travis.sh
@@ -5,8 +5,10 @@ install () {
 
     date
 
-    if [[ -e ~/cache/image.tar.gz ]];
-    then docker load -i ~/cache/image.tar.gz; fi
+    env | sort
+
+    # if [[ -e ~/cache/image.tar.gz ]];
+    # then docker load -i ~/cache/image.tar.gz; fi
 
     # START_BUILD=$(date +%s.%N)
     # echo $START_BUILD


### PR DESCRIPTION
- travis should fail (for all jobs) when the build fails
- don't build twice in packaging jobs
- cut down build time by combining build of alba.native & disk_failure_tests.native