### PR TITLE
sleep in requalify-endpoint loop of proxy_osd

### DIFF
--- a/ocaml/src/proxy_osd.ml
+++ b/ocaml/src/proxy_osd.ml
@@ -128,7 +128,11 @@ class multi_proxy_pool
       | `TryAgain ->
          if !fuse
          then Lwt.return ()
-         else t ()
+         else
+           begin
+             Lwt_extra2.sleep_approx 60. >>= fun () ->
+             t ()
+           end
     in
     let t = t () in
     Hashtbl.add disqualified_endpoints_requalify_threads endpoint (t, fuse);


### PR DESCRIPTION
Had to answer some questions about proxy_osd behavior for kenneth/wim/stefaan and found this issue while verifying afterwards if I hadn't told any lies.