### PR TITLE
Fix #487 proxy apply_sequence doesn't update manifest cache

### DIFF
--- a/ocaml/src/alba_client_sequence.ml
+++ b/ocaml/src/alba_client_sequence.ml
@@ -1,0 +1,113 @@
+(*
+Copyright (C) 2016 iNuron NV
+
+This file is part of Open vStorage Open Source Edition (OSE), as available from
+
+
+    http://www.openvstorage.org and
+    http://www.openvstorage.com.
+
+This file is free software; you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+as published by the Free Software Foundation, in version 3 as it comes
+in the <LICENSE.txt> file of the Open vStorage OSE distribution.
+
+Open vStorage is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY of any kind.
+*)
+
+open Prelude
+open Checksum
+open Lwt.Infix
+
+type object_name = string
+type update =
+  | UploadObjectFromReader of object_name * Object_reader.reader * Checksum.t option
+  | DeleteObject of object_name
+
+let apply_sequence
+      (alba_client : Alba_client.alba_client)
+      (* namespace *) namespace_id
+      (assert_ts : Nsm_model.Assert.t list Lwt.t)
+      (updates : update list)
+      (* stats *)
+  =
+  let t0 = Unix.gettimeofday () in
+  let upload object_name object_reader checksum_o =
+    Alba_client_upload.upload_object''
+      (alba_client # nsm_host_access)
+      (alba_client # osd_access)
+      (alba_client # get_base_client # get_preset_cache # get)
+      (alba_client # get_base_client # get_namespace_osds_info_cache)
+      ~object_t0:t0
+      ~timestamp:t0
+      ~namespace_id
+      ~object_name
+      ~object_reader
+      ~checksum_o
+      ~object_id_hint:None
+      ~fragment_cache:(alba_client # get_base_client # get_fragment_cache)
+      ~cache_on_write:(alba_client # get_base_client # get_cache_on_read_write |> snd)
+    >>= fun (mf, extra_mfs, upload_stats, gc_epoch) ->
+
+    let all_mfs = (mf.Nsm_model.Manifest.name, "", (mf, namespace_id)) ::
+                    (List.map
+                       (fun (mf, namespace_id, alba) ->
+                         mf.Nsm_model.Manifest.name, alba, (mf, namespace_id))
+                       extra_mfs)
+    in
+    Lwt.return (Nsm_model.Update.PutObject (mf, gc_epoch), all_mfs, `Upload (mf, gc_epoch, upload_stats))
+  in
+
+  Lwt_list.map_p
+    (function
+     | UploadObjectFromReader (object_name, object_reader, cs_o) ->
+        upload object_name object_reader cs_o
+     | DeleteObject object_name ->
+        Lwt.return (Nsm_model.Update.DeleteObject object_name, [], `Delete object_name)
+    )
+    updates >>= fun updates ->
+  let updates, manifests, upload_statss = List.split3 updates in
+  let manifests = List.flatten_unordered manifests in
+
+  assert_ts >>= fun asserts ->
+
+  let manifest_cache = alba_client # get_manifest_cache in
+
+  alba_client # nsm_host_access # get_nsm_by_id ~namespace_id >>= fun nsm ->
+  Lwt.catch
+    (fun () ->
+      nsm # apply_sequence asserts updates)
+    (fun exn ->
+      (* clear the manifest cache in error path *)
+      List.iter
+        (function
+         | `Upload (manifest, _, _) ->
+            Manifest_cache.ManifestCache.remove manifest_cache namespace_id manifest.Nsm_model.Manifest.name
+         | `Delete object_name ->
+            Manifest_cache.ManifestCache.remove manifest_cache namespace_id object_name)
+        upload_statss;
+
+      Lwt.fail exn)
+  >>= fun () ->
+
+  (* update manifest cache *)
+  let t1 = Unix.gettimeofday () in
+  let delta = t1 -. t0 in
+  List.iter
+    (function
+     | `Upload (manifest, gc_epoch, upload_stats) ->
+        Alba_client_upload.store_manifest_epilogue
+          (alba_client # osd_access)
+          (alba_client # get_manifest_cache)
+          manifest
+          gc_epoch
+          ~namespace_id
+          (upload_stats delta)
+     | `Delete object_name ->
+        Manifest_cache.ManifestCache.remove
+          (alba_client # get_manifest_cache) namespace_id object_name
+    )
+    upload_statss;
+
+  Lwt.return (manifests, delta)

--- a/ocaml/src/alba_osd.ml
+++ b/ocaml/src/alba_osd.ml
@@ -110,38 +110,29 @@ class client
         | Some _ -> Lwt.return Osd.Success
 
       method apply_sequence prio asserts updates =
-        let prepare_updates namespace_id =
-          let t0 = Unix.gettimeofday () in
-          Lwt_list.map_p
+
+        let apply_sequence_updates =
+          List.map
             (function
-              | Osd.Update.Set (key, None) ->
-                 Lwt.return (Nsm_model.Update.DeleteObject (Slice.get_string_unsafe key))
-              | Osd.Update.Set (key, Some (value, cs, _)) ->
-                 Alba_client_upload.upload_object''
-                   (alba_client # nsm_host_access)
-                   (alba_client # osd_access)
-                   (alba_client # get_base_client # get_preset_cache # get)
-                   (alba_client # get_base_client # get_namespace_osds_info_cache)
-                   ~object_t0:t0
-                   ~timestamp:t0
-                   ~namespace_id
-                   ~object_name:(Slice.get_string_unsafe key)
-                   ~object_reader:(let open Asd_protocol.Blob in
-                                   match value with
-                                   | Lwt_bytes s -> new Object_reader.bytes_reader s
-                                   | Bigslice s -> new Object_reader.bigstring_slice_reader s
-                                   | Bytes s -> new Object_reader.string_reader s
-                                   | Slice s -> new Object_reader.slice_reader s)
-                   ~checksum_o:(Some cs)
-                   ~object_id_hint:None
-                   ~fragment_cache:(alba_client # get_base_client # get_fragment_cache)
-                   ~cache_on_write:(alba_client # get_base_client # get_cache_on_read_write |> snd)
-                 >>= fun (mf, _chunk_fidmos, _, gc_epoch) ->
-                 Lwt.return (Nsm_model.Update.PutObject (mf, gc_epoch)))
+             | Osd.Update.Set (key, None) ->
+                Alba_client_sequence.DeleteObject (Slice.get_string_unsafe key)
+             | Osd.Update.Set (key, Some (value, cs, _)) ->
+                let object_reader =
+                  let open Asd_protocol.Blob in
+                  match value with
+                  | Lwt_bytes s -> new Object_reader.bytes_reader s
+                  | Bigslice s -> new Object_reader.bigstring_slice_reader s
+                  | Bytes s -> new Object_reader.string_reader s
+                  | Slice s -> new Object_reader.slice_reader s
+                in
+                Alba_client_sequence.UploadObjectFromReader
+                  (Slice.get_string_unsafe key,
+                   object_reader,
+                   Some cs))
             updates
         in
 
-        let prepare_asserts () =
+        let assert_ts namespace_id =
           Lwt_list.map_p
             (function
               | Osd.Assert.Value (key, None) ->
@@ -156,7 +147,8 @@ class client
                              ~consistent_read:true
                              ~should_cache:true >>= function
                  | None -> Lwt.fail Nsm_model.Err.(Nsm_exn (Assert_failed, object_name))
-                 | Some (v, mf, _) ->
+                 | Some (v, mf, namespace_id') ->
+                    assert (namespace_id = namespace_id');
                     if Osd.Blob.equal blob (Osd.Blob.Lwt_bytes v)
                     then Lwt.return (Nsm_model.Assert.ObjectHasId
                                        (object_name,
@@ -165,43 +157,24 @@ class client
             asserts
         in
 
-        Lwt.catch
-          (fun () ->
-           let nsm_asserts_t = prepare_asserts () in
-           let nsm_updates_t =
-             alba_client # nsm_host_access # with_namespace_id
-                         ~namespace
-                         prepare_updates
-           in
-           nsm_asserts_t >>= fun nsm_asserts ->
-           nsm_updates_t >>= fun nsm_updates ->
-
-           alba_client # nsm_host_access
-                       # with_nsm_client
-                       ~namespace
-                       (fun nsm ->
-                        nsm # apply_sequence nsm_asserts nsm_updates) >>= fun () ->
-
-           (* update the manifest cache *)
-           alba_client # nsm_host_access # with_namespace_id
-                       ~namespace
-                       (fun namespace_id ->
-                        List.iter
-                          (function
-                            | Nsm_model.Update.DeleteObject _ -> ()
-                            | Nsm_model.Update.PutObject (mf, _) ->
-                               Manifest_cache.ManifestCache.add
-                                 (alba_client # get_manifest_cache)
-                                 namespace_id mf.Nsm_model.Manifest.name mf)
-                          nsm_updates;
-                        Lwt.return ())
-           >>= fun () ->
-           Lwt.return Osd.Ok)
-          (function
-            | Nsm_model.Err.Nsm_exn (Nsm_model.Err.Assert_failed, key) ->
-               Lwt.return (Osd.Exn Osd.Error.(Assert_failed key))
-            | exn ->
-               Lwt.fail exn)
+        alba_client
+          # nsm_host_access
+          # with_namespace_id
+          ~namespace
+          (fun namespace_id ->
+            Lwt.catch
+              (fun () ->
+                Alba_client_sequence.apply_sequence
+                  alba_client
+                  namespace_id
+                  (assert_ts namespace_id)
+                  apply_sequence_updates >>= fun _ ->
+                Lwt.return Osd.Ok)
+              (function
+               | Nsm_model.Err.Nsm_exn (Nsm_model.Err.Assert_failed, key) ->
+                  Lwt.return (Osd.Exn Osd.Error.(Assert_failed key))
+               | exn ->
+                  Lwt.fail exn))
     end
   in
   object(self :# Osd.osd)

--- a/ocaml/src/proxy_server.ml
+++ b/ocaml/src/proxy_server.ml
@@ -151,77 +151,46 @@ let apply_sequence
       updates
       stats
   =
-  let t0 = Unix.gettimeofday () in
-  let upload object_name object_reader checksum_o =
-    Alba_client_upload.upload_object''
-      (alba_client # nsm_host_access)
-      (alba_client # osd_access)
-      (alba_client # get_base_client # get_preset_cache # get)
-      (alba_client # get_base_client # get_namespace_osds_info_cache)
-      ~object_t0:t0
-      ~timestamp:t0
-      ~namespace_id
-      ~object_name
-      ~object_reader
-      ~checksum_o
-      ~object_id_hint:None
-      ~fragment_cache:(alba_client # get_base_client # get_fragment_cache)
-      ~cache_on_write:(alba_client # get_base_client # get_cache_on_read_write |> snd)
-    >>= fun (mf, extra_mfs, upload_stats, gc_epoch) ->
-
-    let all_mfs = (mf.Nsm_model.Manifest.name, "", (mf, namespace_id)) ::
-                    (List.map
-                       (fun (mf, namespace_id, alba) ->
-                         mf.Nsm_model.Manifest.name, alba, (mf, namespace_id))
-                       extra_mfs)
-    in
-    Lwt.return (Nsm_model.Update.PutObject (mf, gc_epoch), all_mfs, `Upload (mf, gc_epoch, upload_stats))
+  let rec with_alba_sequence_updates updates' = function
+    | [] ->
+       Alba_client_sequence.apply_sequence
+         alba_client
+         namespace_id
+         (Lwt.return asserts)
+         updates' >>= fun (mfs, delta) ->
+       List.iter
+         (let open Alba_client_sequence in
+          function
+          | UploadObjectFromReader _ ->
+             ProxyStatistics.new_upload stats namespace delta
+          | DeleteObject _ ->
+             ProxyStatistics.new_delete stats namespace delta)
+         updates';
+       Lwt.return mfs
+    | update :: rest ->
+       let open Protocol.Update in
+       match update with
+       | UploadObjectFromFile (object_name, file_name, cs_o) ->
+          Object_reader.with_file_reader
+            ~use_fadvise:true
+            file_name
+            (fun ~object_reader ->
+              let update' = Alba_client_sequence.UploadObjectFromReader (object_name, object_reader, cs_o) in
+              with_alba_sequence_updates
+                (update' :: updates')
+                rest)
+       | UploadObject (object_name, blob, cs_o) ->
+          let reader = new Object_reader.bigstring_slice_reader blob in
+          let update' = Alba_client_sequence.UploadObjectFromReader (object_name, reader, cs_o) in
+          with_alba_sequence_updates
+            (update' :: updates')
+            rest
+       | DeleteObject object_name ->
+          with_alba_sequence_updates
+            (Alba_client_sequence.DeleteObject object_name :: updates')
+            rest
   in
-
-  Lwt_list.map_p
-    (let open Protocol.Update in
-     function
-     | UploadObjectFromFile (object_name, file_name, cs_o) ->
-        Object_reader.with_file_reader
-          ~use_fadvise:true
-          file_name
-          (fun ~object_reader ->
-            upload object_name
-                   object_reader
-                   cs_o)
-     | UploadObject (object_name, blob, cs_o) ->
-        upload object_name
-               (new Object_reader.bigstring_slice_reader blob)
-               cs_o
-     | DeleteObject object_name ->
-        Lwt.return (Nsm_model.Update.DeleteObject object_name, [], `Delete)
-    )
-    updates >>= fun updates ->
-  let updates, manifests, upload_statss = List.split3 updates in
-  let manifests = List.flatten_unordered manifests in
-
-  alba_client # nsm_host_access # get_nsm_by_id ~namespace_id >>= fun nsm ->
-  nsm # apply_sequence asserts updates >>= fun () ->
-  let () =
-    let t1 = Unix.gettimeofday () in
-    let delta = t1 -. t0 in
-    List.iter
-      (function
-       | `Upload (manifest, gc_epoch, upload_stats) ->
-          Alba_client_upload.store_manifest_epilogue
-            (alba_client # osd_access)
-            (alba_client # get_manifest_cache)
-            manifest
-            gc_epoch
-            ~namespace_id
-            (upload_stats delta);
-          ProxyStatistics.new_upload stats namespace delta
-       | `Delete ->
-          ProxyStatistics.new_delete stats namespace delta
-      )
-      upload_statss
-  in
-  Lwt.return manifests
+  with_alba_sequence_updates [] updates
 
 
 let read_objects

--- a/ocaml/src/proxy_server.ml
+++ b/ocaml/src/proxy_server.ml
@@ -167,7 +167,15 @@ let apply_sequence
       ~object_id_hint:None
       ~fragment_cache:(alba_client # get_base_client # get_fragment_cache)
       ~cache_on_write:(alba_client # get_base_client # get_cache_on_read_write |> snd)
-    >>= fun (mf, extra_mfs, _upload_stats, gc_epoch) ->
+    >>= fun (mf, extra_mfs, upload_stats, gc_epoch) ->
+
+    let t1 = Unix.gettimeofday () in
+    let delta = t1 -. t0 in
+    Lwt_log.debug_f
+      ~section:Alba_statistics.Statistics.section
+      "Uploaded object %S with the following timings: %s"
+      object_name (Alba_statistics.Statistics.show_object_upload (upload_stats delta)) >>= fun () ->
+
     let all_mfs = (mf.Nsm_model.Manifest.name, "", (mf, namespace_id)) ::
                     (List.map
                        (fun (mf, namespace_id, alba) ->

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -1777,7 +1777,12 @@ module Test = struct
     let () = Printf.printf "cmd_s = %s\n%!" cmd_s in
     cmd_s |> Shell.cmd_with_rc
 
-  let voldrv_tests ?(xml = false) ?filter ?dump t =
+  let voldrv_tests
+        ?(xml = false)
+        ?(filter="SimpleVolumeTests/SimpleVolumeTest*:DataStoreNGTests/DataStoreNGTest.*")
+        ?dump
+        t
+    =
     let cfg = t.Deployment.cfg in
     let () = _create_preset t
                             "preset_rora"
@@ -1797,10 +1802,7 @@ module Test = struct
       else cmd
     in
     let cmd2 = if xml then cmd @ ["--gtest_output=xml:testresults.xml"] else cmd in
-    let cmd3 = match filter with
-      | None -> cmd2 @ ["--gtest_filter=SimpleVolumeTests/SimpleVolumeTest*:DataStoreNGTests/DataStoreNGTest.corruptedReadSCO/0"]
-      | Some filter -> cmd2 @ ["--gtest_filter=" ^ filter]
-    in
+    let cmd3 = cmd2 @ ["--gtest_filter=" ^ filter] in
     let cmd4 = match dump with
       | None -> cmd3
       | Some dump -> cmd3 @ ["> " ^ dump ^ " 2>&1"]

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -1798,7 +1798,7 @@ module Test = struct
     in
     let cmd2 = if xml then cmd @ ["--gtest_output=xml:testresults.xml"] else cmd in
     let cmd3 = match filter with
-      | None -> cmd2 @ ["--gtest_filter=SimpleVolumeTests/SimpleVolumeTest*"]
+      | None -> cmd2 @ ["--gtest_filter=SimpleVolumeTests/SimpleVolumeTest*:DataStoreNGTests/DataStoreNGTest.corruptedReadSCO/0"]
       | Some filter -> cmd2 @ ["--gtest_filter=" ^ filter]
     in
     let cmd4 = match dump with


### PR DESCRIPTION
Also, it didn't clear the manifest cache when deleting an object, and this issue was present in the alba_osd code too. So extracted the commonalities and fixed that too.