### PR TITLE
Improvements related to #427

### DIFF
--- a/ocaml/src/cli_common.ml
+++ b/ocaml/src/cli_common.ml
@@ -20,15 +20,8 @@ open Cmdliner
 open Lwt.Infix
 
 let stderr_logger =
-  let mutex = Lwt_mutex.create () in
-  let lg_output line =
-    Lwt_mutex.with_lock
-      mutex
-      (fun () ->
-       Lwt_io.write Lwt_io.stderr line >>= fun () ->
-       Lwt_io.write_char Lwt_io.stdout '\n')
-  in
-  let close () = Lwt.return_unit in
+  let lg_output = Lwt_io.eprintl in
+  let close = Lwt.return in
   lg_output, close
 
 let log_sinks =

--- a/ocaml/src/osd_access.ml
+++ b/ocaml/src/osd_access.ml
@@ -114,7 +114,7 @@ module Osd_pool = struct
            ~prefix ~preset_name:(Some preset)
            ~namespace_name_format:1 >>= fun (client, closer) ->
          Lwt.return ((function
-                      | OsdInfo.Alba { OsdInfo.cfg; } -> cfg_ref := cfg;
+                      | OsdInfo.Alba2 { OsdInfo.cfg; } -> cfg_ref := cfg;
                       | _ -> assert false),
                      client,
                      closer)

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -2509,7 +2509,7 @@ module Test = struct
 
     0
 
-  let alba_as_osd ?xml ?filter ?dump _t =
+  let setup_global_backend () =
     let workspace = env_or_default "WORKSPACE" (Unix.getcwd ()) in
     Shell.cmd_with_capture [ "rm"; "-rf"; workspace ^ "/tmp" ] |> print_endline;
 
@@ -2572,6 +2572,19 @@ module Test = struct
     add_backend_as_osd t_local3 `ProxyOsd;
     add_backend_as_osd t_local4 `ProxyOsd;
     Deployment.deliver_messages t_global;
+
+    cfg_global, t_global,
+    [ t_local1; t_local2; t_local3; t_local4; ],
+    add_backend_as_osd
+
+  let alba_as_osd ?xml ?filter ?dump _t =
+    let cfg_global, t_global, t_locals, add_backend_as_osd =
+      setup_global_backend ()
+    in
+    let t_local1, t_local2, t_local3, t_local4 = match t_locals with
+      | [ t_local1; t_local2; t_local3; t_local4; ] -> t_local1, t_local2, t_local3, t_local4
+      | _ -> assert false
+    in
 
     let do_upload objname =
       t_global.proxy # upload_object "demo" cfg_global.alba_bin objname
@@ -2663,6 +2676,25 @@ module Test = struct
     t_global.proxy # download_object "demo" objname "/tmp/fdsi";
     t_global.proxy # download_object "demo" "3" "/tmp/fdsi";
 
+    0
+
+  let test_427 ?xml ?filter ?dump _ =
+    let cfg_global, t_global, _, _ = setup_global_backend () in
+
+    let proxy = t_global.proxy in
+
+    let rec inner = function
+      | 100 -> ()
+      | n ->
+         let namespace = Printf.sprintf "ns_%i" n in
+         let objname = "obj" in
+         proxy # create_namespace namespace;
+         proxy # upload_object namespace cfg_global.alba_bin objname;
+         proxy # download_object namespace objname "/tmp/427.obj";
+         proxy # delete_namespace namespace;
+         inner (n + 1)
+    in
+    inner 0;
     0
 
   let everything_else ?(xml=false) ?filter ?dump t =
@@ -2863,6 +2895,7 @@ let process_cmd_line () =
       "asd_transport_combos", Test.asd_transport_combos, false;
       "rora",            Test.rora, false;
       "recovery",        Test.recovery, true;
+      "test_427",        Test.test_427, false;
     ]
   in
   let print_suites () =


### PR DESCRIPTION
See #427.
The added test could first reproduce this, and after the changes to message delivery on namespace creation it now succeeds (most of the time, see message about segfault below).
Of course @JeffreyDevloo will want to verify this too: you can find a fresh package @ http://10.100.129.100:8080/view/alba2/job/alba_docker_generic_package_ubuntu-16.04/lastSuccessfulBuild/artifact/alba_1.2.4-83-g9da540f_amd64.deb

In an unexpected turn of events the new test also allows reproducing a segfault which I still have to investigate - but which I believe to be unrelated to this pull request.