### PR TITLE
proxy shouldn't try to discover asds

### DIFF
--- a/ocaml/src/proxy_osd_test.ml
+++ b/ocaml/src/proxy_osd_test.ml
@@ -21,6 +21,7 @@ open Lwt.Infix
 
 let test_with_kvs_client test_name f =
   let t () =
+    Lwt_log.debug_f "Starting proxy_osd_test %s" test_name >>= fun () ->
     let ip, port, transport =
       let open Proxy_test in
       _IP, _PORT, _TRANSPORT

--- a/ocaml/src/proxy_server.ml
+++ b/ocaml/src/proxy_server.ml
@@ -888,8 +888,7 @@ let run_server hosts port ~transport
          ~upload_slack
          (fun alba_client ->
           Lwt.pick
-            [ (alba_client # discover_osds ~check_claimed:(fun _ -> true) ());
-              (alba_client # osd_access # propagate_osd_info ());
+            [ (alba_client # osd_access # propagate_osd_info ());
               (refresh_albamgr_cfg
                  ~loop:true
                  albamgr_client_cfg

--- a/ocaml/src/proxy_test.ml
+++ b/ocaml/src/proxy_test.ml
@@ -28,13 +28,13 @@ let _IP,_PORT,_TRANSPORT =
     ("127.0.0.1", 10_000, Net_fd.TCP)
 
                    
+let with_proxy_client f =
+  Proxy_client.with_client
+    _IP _PORT _TRANSPORT
+    f
+
 let test_with_proxy_client f =
-  let t =
-    Proxy_client.with_client
-      _IP _PORT _TRANSPORT
-      f
-  in
-  Lwt_main.run t
+  Lwt_main.run (with_proxy_client f)
 
 let assert_proxy_error f err =
   Lwt.catch

--- a/ocaml/src/remotes.ml
+++ b/ocaml/src/remotes.ml
@@ -54,8 +54,9 @@ module Pool = struct
       Lwt_pool2.create
         size
         ~check:(fun _ exn ->
-            (* TODO some exns shouldn't invalidate the connection *)
-            false)
+          (* TODO some exns shouldn't invalidate the connection *)
+          Lwt_log.ign_debug_f ~exn "Throwing an abm connection away after an exception";
+          false)
         ~factory
         ~cleanup:(fun (_, closer) -> closer ())
 


### PR DESCRIPTION
the maintenance will still do it, and we don't depend on it for correct functioning of the proxy