### PR TITLE
get-osd-claimed-by

### DIFF
--- a/ocaml/src/cli_common.ml
+++ b/ocaml/src/cli_common.ml
@@ -249,6 +249,13 @@ let port default =
        & opt int default
        & info ["p"; "port"] ~docv:"PORT" ~doc)
 
+let port_option =
+  Arg.(value
+       & opt (some int) None
+       & info ["port"; "p";]
+              ~docv:"PORT"
+              ~doc:"the port to connect with")
+
 let attempts default =
   let doc = "number of attempts" in
   Arg.(value
@@ -266,6 +273,13 @@ let hosts =
   Arg.(value
        & opt_all string []
        & info ["h";"host"] ~docv:"HOST" ~doc)
+
+let host_option =
+  Arg.(value
+       & opt (some string) None
+       & info ["host"; "h";]
+              ~docv:"HOST"
+              ~doc:"the host to connect with")
 
 let transport =
   let (tr : Net_fd.transport Arg.converter) =


### PR DESCRIPTION
As requested in #629

```
$ ./alba get-osd-claimed-by -h 192.168.11.127 -p 8041 --verbose --to-json 2>/dev/null
{"success":false,"error":{"message":"(Failure \"I don't think this is an OSD\")","exception_type":"unknown","exception_code":0}}

$ ./alba get-osd-claimed-by -h 192.168.11.127 -p 8011 --verbose --to-json 2>/dev/null
{ "success": true, "result": "ebadb63d-79ff-4226-a53e-13a968bb4e0a" }

$ ./alba get-osd-claimed-by -h 192.168.11.127 -p 8011 --verbose --to-json 2>/dev/null
{ "success": true, "result": null }
```