### PR TITLE
maintenance should stop RewriteObject for deleted namespaces & disk safety smaller than -k makes no sense

### DIFF
--- a/ocaml/src/disk_safety.ml
+++ b/ocaml/src/disk_safety.ml
@@ -58,7 +58,7 @@ let get_namespace_safety
          { bucket;
            count;
            applicable_dead_osds;
-           remaining_safety = (fragment_count-k) - applicable_dead_osds;
+           remaining_safety = max ((fragment_count-k) - applicable_dead_osds) (-k);
          }
       ) |>
     List.sort


### PR DESCRIPTION
fixes #638 
fixes #640 