### PR TITLE
synchronous blob deletes from asd io scheduler, to prevent them from …

### DIFF
--- a/ocaml/src/asd_server.ml
+++ b/ocaml/src/asd_server.ml
@@ -849,11 +849,13 @@ let cleanup_files_to_delete ignore_unlink_error io_sched prio kv dir_info fnrs =
          (* TODO bulk sync of (unique) parent filedescriptors *)
          perform_delete
            io_sched
-           prio >>= fun () ->
-         Lwt_extra2.unlink
-           ~may_not_exist:(ignore_unlink_error || not dir_info.DirectoryInfo.write_blobs)
-           ~fsync_parent_dir:true
-           path)
+           prio
+           (fun () ->
+             Lwt_extra2.unlink
+               ~may_not_exist:(ignore_unlink_error || not dir_info.DirectoryInfo.write_blobs)
+               ~fsync_parent_dir:true
+               path)
+      )
       fnrs >>= fun () ->
 
     List.iter


### PR DESCRIPTION
…queueing up


related to https://github.com/openvstorage/alba/issues/624 , it should slow the deletes down a bit.
Not sure if it will actually fix the scenario of the ticket (mass delete of namespaces from fragment cache).