### PR TITLE
burn through less albamgr & nsm host & osd connections

### DIFF
--- a/ocaml/src/osd_access.ml
+++ b/ocaml/src/osd_access.ml
@@ -154,9 +154,13 @@ module Osd_pool = struct
             let p =
               Lwt_pool2.create
                 t.pool_size
-                ~check:(fun _ exn ->
-                        (* TODO some exns shouldn't invalidate the connection *)
-                        false)
+                ~check:(fun _ ->
+                  function
+                  | Asd_protocol.Protocol.Error.Exn _ ->
+                     true
+                  | exn ->
+                     Lwt_log.ign_info_f ~exn "Throwing an osd connection away after an exception";
+                     false)
                 ~factory
                 ~cleanup:(fun (_, closer) -> closer ())
             in


### PR DESCRIPTION
improvement (fix?) for #671 

@dejonghb saw an Osd_already_exists error coming back from the abm, after which the connection was closed, which lead me down this path...