### PR TITLE
allow disabling listening for multicast messages from maintenance

### DIFF
--- a/cfg/asd_demo.json
+++ b/cfg/asd_demo.json
@@ -28,6 +28,9 @@
     // optional, by default we use 99% of the capacity
     , "limit" : 99
 
+    , "multicast" : 10. // optional, default 10. can be disabled by setting to null
+                        // specifies the multicast interval in seconds
+
     // optional:
     , "tls" : {"cert": "path/to/cert",
                "key" : "path/to/key",

--- a/cfg/maintenance_demo.json
+++ b/cfg/maintenance_demo.json
@@ -17,4 +17,6 @@
     }
     // node_ids of osds that are considered closer, default []
     , "read_preference" : []
+    , "multicast_discover_osds" : false // optional, default true. specifies whether maintenance
+                                        // should listen to asd/kinetic multicast messages or not
 }


### PR DESCRIPTION
Not strictly necessary, but related to https://github.com/openvstorage/framework-alba-plugin/issues/378