### PR TITLE
fix for "resource temporarily unavailable" error during partial read

### DIFF
--- a/ocaml/src/tools/alba_partial_read_stubs.c
+++ b/ocaml/src/tools/alba_partial_read_stubs.c
@@ -106,8 +106,10 @@ static void worker_partial_read(struct job_partial_read* job)
                     pollfd.events = POLLOUT;
                     pollfd.revents = 0;
                     ok = poll(&pollfd, 1, -1);
-                    if (ok) {
+                    if (ok == 1) {
                         ok = (pollfd.revents == POLLOUT);
+                    } else {
+                        ok = false;
                     }
                     sent = 0;
                 }

--- a/ocaml/src/tools/alba_partial_read_stubs.c
+++ b/ocaml/src/tools/alba_partial_read_stubs.c
@@ -30,6 +30,8 @@
 #include <sys/sendfile.h>
 #include <assert.h>
 
+#include <poll.h>
+
 struct job_partial_read {
   /*  used by lwt.
       MUST be the first field of the structure. */
@@ -97,10 +99,24 @@ static void worker_partial_read(struct job_partial_read* job)
         do {
             int sent = sendfile(job -> socket, in_fd, &offset, todo);
             if(sent == -1){
-                job -> result = -1;
-                job -> errno_copy = errno;
-                close(in_fd);
-                return;
+                int ok = -1;
+                if (errno == EAGAIN || errno == EWOULDBLOCK){
+                    struct pollfd pollfd;
+                    pollfd.fd = job->socket;
+                    pollfd.events = POLLOUT;
+                    pollfd.revents = 0;
+                    ok = poll(&pollfd, 1, -1);
+                    if (ok) {
+                        ok = (pollfd.revents == POLLOUT);
+                    }
+                    sent = 0;
+                }
+                if (!ok) {
+                    job -> result = -1;
+                    job -> errno_copy = errno;
+                    close(in_fd);
+                    return;
+                }
             }
             todo = todo - sent;
         } while(todo > 0);


### PR DESCRIPTION
saw
```
Mar 29 15:54:25 ftcmp03 alba[17292]: 2017-03-29 15:54:25 445739 +0200 - ftcmp03 - 17292/0 - alba/asd - 15439 - info - server: exception occurred in client connection (172.22.186.32,48602): (Unix.Unix_error "Resource temporarily unavailable" partial_read;   /mnt/alba-asd/glrsTbu5QObLHo1P/70eLNFSsuOtkMn7cJwziBBvqBgUdhqt4/blobs/00/00/00/00/00/0e/e7/00000000000ee7f3)
```
on the env of @dejonghb 

Still waiting for jenkins and validation by @dejonghb 